### PR TITLE
Support for Integer and Float Literals Added to Majestik Grammar and Compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ Components
 Majestik is composed of three core components:
 1. Lexer/Parser: This component parses the Magik source code and constructs an Abstract Syntax Tree (AST).
 
-   Currently, the ANTLR4 grammar only understands the literal type `string`; the expression `invoke` and `block` statements, as well as simple assignments (`<<`).  All other tokens are ignored.
+   Currently, the ANTLR4 grammar only understands the literal types `string`, `integer` and `float`; the expression `invoke` and `block` statements, as well as simple assignments (`<<`).  All other tokens are ignored.
 3. Compiler: This component translates the AST into JVM bytecode using the Class-File API.
 
-   Currently, only supports literal type `string`, and `invoke` expressions.
+   Currently, only supports literal types `string`, `integer` and `float`; as well as the `invoke` expressions.
 4. Runtime: provides a standard library with basic functionality to run a Magik program.
 
    As of now, only the `write` variable in the `sw` package has a barebones implementation.
@@ -26,9 +26,15 @@ Features
 In the project's current state, it is possible (and pretty much limited just to) run a Magik "Hello World" example program[^4].
 ```magik
 _block
-   world << "World!"
-   write("Hello ")
-   write(world)
+  world << "World!"
+  write("Hello")
+  write(world)
+
+  int << 12345
+  write(int)
+
+  flt << 5.4321
+  write(flt)
 _endblock
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ Majestik is composed of three core components:
 1. Lexer/Parser: This component parses the Magik source code and constructs an Abstract Syntax Tree (AST).
 
    Currently, the ANTLR4 grammar only understands the literal types `string`, `integer` and `float`; the expression `invoke` and `block` statements, as well as simple assignments (`<<`).  All other tokens are ignored.
-3. Compiler: This component translates the AST into JVM bytecode using the Class-File API.
+2. Compiler: This component translates the AST into JVM bytecode using the Class-File API.
 
    Currently, only supports literal types `string`, `integer` and `float`; as well as the `invoke` expressions.
-4. Runtime: provides a standard library with basic functionality to run a Magik program.
+3. Runtime: provides a standard library with basic functionality to run a Magik program.
 
    As of now, only the `write` variable in the `sw` package has a barebones implementation.
 

--- a/src/main/antlr4/com/keronic/antlr4/Majestik.g4
+++ b/src/main/antlr4/com/keronic/antlr4/Majestik.g4
@@ -19,6 +19,10 @@ expression
     | invoke
     ;
 
+number
+    : NUMBER
+    ;
+
 string
     : STRING
     ;
@@ -33,11 +37,13 @@ lhs
 
 rhs
     : var
+    | number
     | string
     ;
 
 argument
     : var
+    | number
     | string
     ;
 
@@ -107,3 +113,7 @@ BLOCK : '_' B L O C K;
 ENDBLOCK : '_' E N D B L O C K;
 
 ASSIGN : '<<';
+
+NUMBER : [0-9]+
+       | [0-9]* '.' [0-9]+
+       ;

--- a/src/main/java/com/keronic/MajestikCodeVisitor.java
+++ b/src/main/java/com/keronic/MajestikCodeVisitor.java
@@ -2,7 +2,6 @@ package com.keronic;
 
 import java.lang.classfile.CodeBuilder;
 import java.lang.constant.ClassDesc;
-import java.lang.constant.ConstantDescs;
 import java.lang.constant.DirectMethodHandleDesc;
 import java.lang.constant.DynamicCallSiteDesc;
 import java.lang.constant.MethodTypeDesc;
@@ -12,31 +11,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
+import com.keronic.majestik.constant.ConstantDescs;
 import com.keronic.antlr4.MajestikBaseVisitor;
 import com.keronic.antlr4.MajestikParser;
 
 public class MajestikCodeVisitor extends MajestikBaseVisitor<Void> {
-
-	static final ClassDesc CD_PrintStream = ClassDesc.of("java.io.PrintStream");
-	static final ClassDesc CD_System = ClassDesc.of("java.lang.System");
-	static final ClassDesc CD_ConstantBuilder = ClassDesc.of("com.keronic.majestik.language.invokers.ConstantBuilder");
-	static final ClassDesc CD_GlobalAccessor = ClassDesc.of("com.keronic.majestik.language.invokers.GlobalAccessor");
-	static final ClassDesc CD_ProcInvoker = ClassDesc.of("com.keronic.majestik.language.invokers.ProcInvoker");
-
-	static final DirectMethodHandleDesc BSM_STRING_BUILDER = ConstantDescs.ofCallsiteBootstrap(CD_ConstantBuilder,
-			"stringBootstrap", ConstantDescs.CD_CallSite, ConstantDescs.CD_String);
-	static final DirectMethodHandleDesc BSM_GLOBAL_FETCHER = ConstantDescs.ofCallsiteBootstrap(CD_GlobalAccessor,
-			"bootstrapFetcher2", ConstantDescs.CD_CallSite, ConstantDescs.CD_String, ConstantDescs.CD_String);
-	static final DirectMethodHandleDesc BSM_NATURAL_PROC = ConstantDescs.ofCallsiteBootstrap(CD_ProcInvoker,
-			"naturalBootstrap", ConstantDescs.CD_CallSite);
-
-	static final MethodTypeDesc MTD_Object = MethodTypeDesc.of(ConstantDescs.CD_Object);
-	static final MethodTypeDesc MTD_ObjectObjectObject = MethodTypeDesc.of(ConstantDescs.CD_Object,
-			ConstantDescs.CD_Object, ConstantDescs.CD_Object);
-	static final MethodTypeDesc MTD_Doubledouble = MethodTypeDesc.of(ConstantDescs.CD_Double,
-			ConstantDescs.CD_double);
-	static final MethodTypeDesc MTD_Longlong = MethodTypeDesc.of(ConstantDescs.CD_Long,
-			ConstantDescs.CD_long);
 
 	CodeBuilder cb;
 	List<String> varList = new ArrayList<String>();
@@ -60,7 +39,7 @@ public class MajestikCodeVisitor extends MajestikBaseVisitor<Void> {
 		String quotedString = ctx.getText();
 		String pureString = normalizeString(quotedString);
 
-		this.cb.invokedynamic(DynamicCallSiteDesc.of(BSM_STRING_BUILDER, "string", MTD_Object, pureString));
+		this.cb.invokedynamic(DynamicCallSiteDesc.of(ConstantDescs.BSM_STRING_BUILDER, "string", ConstantDescs.MTD_Object, pureString));
 		return visitChildren(ctx);
 	}
 
@@ -78,10 +57,10 @@ public class MajestikCodeVisitor extends MajestikBaseVisitor<Void> {
 			var number = NumberFormat.getInstance(Locale.ROOT).parse(numberString);
 			if (number instanceof Long n) {
 				this.cb.constantInstruction(n);
-				this.cb.invokestatic(ConstantDescs.CD_Long, "valueOf", MTD_Longlong);
+				this.cb.invokestatic(ConstantDescs.CD_Long, "valueOf", ConstantDescs.MTD_Longlong);
 			} else if (number instanceof Double n) {
 				this.cb.constantInstruction(n);
-				this.cb.invokestatic(ConstantDescs.CD_Double, "valueOf", MTD_Doubledouble);
+				this.cb.invokestatic(ConstantDescs.CD_Double, "valueOf", ConstantDescs.MTD_Doubledouble);
 			}
 		} catch (ParseException e) {
 			throw new RuntimeException("Failed to parse number: " + numberString, e);
@@ -101,14 +80,14 @@ public class MajestikCodeVisitor extends MajestikBaseVisitor<Void> {
 	@Override
 	public Void visitInvoke(MajestikParser.InvokeContext ctx) {
 		this.cb.invokedynamic(
-				DynamicCallSiteDesc.of(BSM_GLOBAL_FETCHER, "fetch", MTD_Object, "sw", ctx.name.getText()));
+				DynamicCallSiteDesc.of(ConstantDescs.BSM_GLOBAL_FETCHER, "fetch", ConstantDescs.MTD_Object, "sw", ctx.name.getText()));
 
 		var result = visitChildren(ctx);
 
 		// https://docs.oracle.com/en/java/javase/22/docs/api/java.base/java/lang/invoke/CallSite.html
 
 		System.out.println("LOG: - Compiling invoke...");
-		this.cb.invokedynamic(DynamicCallSiteDesc.of(BSM_NATURAL_PROC, "()", MTD_ObjectObjectObject));
+		this.cb.invokedynamic(DynamicCallSiteDesc.of(ConstantDescs.BSM_NATURAL_PROC, "()", ConstantDescs.MTD_ObjectObjectObject));
 
 		return result;
 	}

--- a/src/main/java/com/keronic/MajestikCodeVisitor.java
+++ b/src/main/java/com/keronic/MajestikCodeVisitor.java
@@ -84,8 +84,7 @@ public class MajestikCodeVisitor extends MajestikBaseVisitor<Void> {
 				this.cb.invokestatic(ConstantDescs.CD_Double, "valueOf", MTD_Doubledouble);
 			}
 		} catch (ParseException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
+			throw new RuntimeException("Failed to parse number: " + numberString, e);
 		}
 
 		return visitChildren(ctx);

--- a/src/main/java/com/keronic/MajestikCodeVisitor.java
+++ b/src/main/java/com/keronic/MajestikCodeVisitor.java
@@ -44,9 +44,10 @@ public class MajestikCodeVisitor extends MajestikBaseVisitor<Void> {
 	}
 
 	private String normalizeString(String quotedString) {
-		assert quotedString.length() >= 2;
-		assert quotedString.charAt(0) == '\"' && quotedString.charAt(quotedString.length() - 1) == '\"' ||
-				quotedString.charAt(0) == '\'' && quotedString.charAt(quotedString.length() - 1) == '\'';
+		assert quotedString.length() >= 2 : "String length is too short to be valid.";
+		assert (quotedString.charAt(0) == '\"' && quotedString.charAt(quotedString.length() - 1) == '\"') ||
+				(quotedString.charAt(0) == '\'' && quotedString.charAt(quotedString.length() - 1) == '\'')
+				: "String is not properly quoted.";
 		return quotedString.substring(1, quotedString.length() - 1);
 	}
 

--- a/src/main/java/com/keronic/majestik/constant/ConstantDescs.java
+++ b/src/main/java/com/keronic/majestik/constant/ConstantDescs.java
@@ -1,0 +1,37 @@
+package com.keronic.majestik.constant;
+
+import java.lang.constant.ClassDesc;
+import java.lang.constant.DirectMethodHandleDesc;
+import java.lang.constant.MethodTypeDesc;
+
+public final class ConstantDescs {
+
+	public static final ClassDesc CD_double = java.lang.constant.ConstantDescs.CD_double;
+	public static final ClassDesc CD_long = java.lang.constant.ConstantDescs.CD_long;
+	public static final ClassDesc CD_CallSite = java.lang.constant.ConstantDescs.CD_CallSite;
+	public static final ClassDesc CD_Double = java.lang.constant.ConstantDescs.CD_Double;
+	public static final ClassDesc CD_Long = java.lang.constant.ConstantDescs.CD_Long;
+	public static final ClassDesc CD_Object = java.lang.constant.ConstantDescs.CD_Object;
+	public static final ClassDesc CD_String = java.lang.constant.ConstantDescs.CD_String;
+
+	public static final ClassDesc CD_PrintStream = ClassDesc.of("java.io.PrintStream");
+	public static final ClassDesc CD_System = ClassDesc.of("java.lang.System");
+	public static final ClassDesc CD_ConstantBuilder = ClassDesc.of("com.keronic.majestik.language.invokers.ConstantBuilder");
+	public static final ClassDesc CD_GlobalAccessor = ClassDesc.of("com.keronic.majestik.language.invokers.GlobalAccessor");
+	public static final ClassDesc CD_ProcInvoker = ClassDesc.of("com.keronic.majestik.language.invokers.ProcInvoker");
+
+	public static final DirectMethodHandleDesc BSM_STRING_BUILDER = java.lang.constant.ConstantDescs.ofCallsiteBootstrap(CD_ConstantBuilder,
+			"stringBootstrap", CD_CallSite, CD_String);
+	public static final DirectMethodHandleDesc BSM_GLOBAL_FETCHER = java.lang.constant.ConstantDescs.ofCallsiteBootstrap(CD_GlobalAccessor,
+			"bootstrapFetcher2", CD_CallSite, CD_String, CD_String);
+	public static final DirectMethodHandleDesc BSM_NATURAL_PROC = java.lang.constant.ConstantDescs.ofCallsiteBootstrap(CD_ProcInvoker,
+			"naturalBootstrap", ConstantDescs.CD_CallSite);
+
+	public static final MethodTypeDesc MTD_Object = MethodTypeDesc.of(ConstantDescs.CD_Object);
+	public static final MethodTypeDesc MTD_ObjectObjectObject = MethodTypeDesc.of(ConstantDescs.CD_Object,
+			ConstantDescs.CD_Object, ConstantDescs.CD_Object);
+	public static final MethodTypeDesc MTD_Doubledouble = MethodTypeDesc.of(ConstantDescs.CD_Double,
+			ConstantDescs.CD_double);
+	public static final MethodTypeDesc MTD_Longlong = MethodTypeDesc.of(ConstantDescs.CD_Long,
+			ConstantDescs.CD_long);
+}

--- a/src/main/java/com/keronic/majestik/language/invokers/DynamicAccessor.java
+++ b/src/main/java/com/keronic/majestik/language/invokers/DynamicAccessor.java
@@ -16,8 +16,8 @@ public class DynamicAccessor {
 	private static MethodHandle todo;
 
 	public static void todo(Object o) {
-    	System.out.format("DYNAMIC: %s\n", o);
-    }
+		// System.out.format("DYNAMIC: %s\n", o);
+	}
 
     static {
     	try {

--- a/src/main/java/com/keronic/majestik/language/invokers/DynamicAccessor.java
+++ b/src/main/java/com/keronic/majestik/language/invokers/DynamicAccessor.java
@@ -16,7 +16,7 @@ public class DynamicAccessor {
 	private static MethodHandle todo;
 
 	public static void todo(Object o) {
-		// System.out.format("DYNAMIC: %s\n", o);
+		// TODO: implement lookup of dynamic variables
 	}
 
     static {

--- a/src/main/java/com/keronic/majestik/language/invokers/ProcInvoker.java
+++ b/src/main/java/com/keronic/majestik/language/invokers/ProcInvoker.java
@@ -18,9 +18,8 @@ public class ProcInvoker {
 	private static MethodHandle todo;
 
 	public static Object todo(Object o1, Object o2) {
-		ProcImpl proc = (ProcImpl) o1;
 		try {
-			// System.out.format("PROCINVOKE: %s %s\n", o1, o2);
+			ProcImpl proc = (ProcImpl) o1;
 			proc.invoke(o1, o2);
 		} catch (Throwable e) {
 			// TODO Auto-generated catch block

--- a/src/main/java/com/keronic/majestik/language/invokers/ProcInvoker.java
+++ b/src/main/java/com/keronic/majestik/language/invokers/ProcInvoker.java
@@ -18,32 +18,31 @@ public class ProcInvoker {
 	private static MethodHandle todo;
 
 	public static Object todo(Object o1, Object o2) {
-//		MutableCallSite proccs = new MutableCallSite(MethodType.methodType(ProcImpl.class));
-		ProcImpl proc = (ProcImpl)o1;
+		ProcImpl proc = (ProcImpl) o1;
 		try {
-    		System.out.format("PROCINVOKE: %s %s\n", o1, o2);
+			// System.out.format("PROCINVOKE: %s %s\n", o1, o2);
 			proc.invoke(o1, o2);
 		} catch (Throwable e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 		return null;
-    }
+	}
 
-    static {
-    	try {
+	static {
+		try {
 			todo = MethodHandles.lookup().findStatic(ProcInvoker.class, "todo", MethodType.genericMethodType(2));
 		} catch (Exception e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
-    }
+	}
 
-    public static CallSite tupleBootstrap(MethodHandles.Lookup lookup, String name, MethodType type) {
-        return new ConstantCallSite(todo);
-    }
+	public static CallSite tupleBootstrap(MethodHandles.Lookup lookup, String name, MethodType type) {
+		return new ConstantCallSite(todo);
+	}
 
 	public static CallSite naturalBootstrap(MethodHandles.Lookup lookup, String name, MethodType type) {
-        return new ConstantCallSite(todo);
-    }
+		return new ConstantCallSite(todo);
+	}
 }

--- a/src/main/java/com/keronic/majestik/language/invokers/ProcInvoker.java
+++ b/src/main/java/com/keronic/majestik/language/invokers/ProcInvoker.java
@@ -32,8 +32,7 @@ public class ProcInvoker {
 		try {
 			todo = MethodHandles.lookup().findStatic(ProcInvoker.class, "todo", MethodType.genericMethodType(2));
 		} catch (Exception e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
+			throw new RuntimeException(e);
 		}
 	}
 

--- a/src/test/java/com/keronic/antlr4/test/LexerTest.java
+++ b/src/test/java/com/keronic/antlr4/test/LexerTest.java
@@ -68,6 +68,20 @@ public class LexerTest {
 	}
 
 	@Test
+	public void testNumberLong() throws IOException {
+		var tokens = this.getTokensFromText("54321");
+		assertEquals(1, tokens.size());
+		assertEquals(MajestikLexer.NUMBER, tokens.get(0).getType());
+	}
+
+	@Test
+	public void testNumberDouble() throws IOException {
+		var tokens = this.getTokensFromText("5.4321");
+		assertEquals(1, tokens.size());
+		assertEquals(MajestikLexer.NUMBER, tokens.get(0).getType());
+	}
+
+	@Test
 	public void testVariable() throws IOException {
 		var tokens = this.getTokensFromText("var");
 		assertEquals(1, tokens.size());

--- a/src/test/java/com/keronic/antlr4/test/ParserTest.java
+++ b/src/test/java/com/keronic/antlr4/test/ParserTest.java
@@ -36,9 +36,7 @@ public class ParserTest {
 	}
 
 	static String toStringTree(RuleContext ctx) {
-		var result = ctx.toStringTree().replaceAll("\\[[\\ 0-9]*\\]\\ ", "");
-		System.out.println(result);
-		return result;
+		return ctx.toStringTree().replaceAll("\\[[\\ 0-9]*\\]\\ ", "");
 	}
 
 	@Test
@@ -61,8 +59,6 @@ public class ParserTest {
 				new CommonToken(MajestikLexer.VAR, "arg"),
 				new CommonToken(MajestikLexer.RIGHT_RBRACKET, ")")));
 		var invoke = parser.invoke();
-
-		System.out.println(invoke.toStringTree());
 		assertEquals("(proc ( (((arg))) ))", toStringTree(invoke));
 		assertEquals(1, invoke.argss.children.size());
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Support for `integer`, `float`, and `number` literal types added to the ANTLR4 grammar, Compiler, and Runtime components.

- **Bug Fixes**
  - Adjustments for number parsing and conversions in `visitNumber`, `visitVar`, and `visitAssign` methods to handle `Long` and `Double`.

- **Tests**
  - Added tests for long and double number handling in `LexerTest`.

- **Refactor**
  - Simplified `toStringTree` method in `ParserTest` for more concise implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->