### PR TITLE
Prevent Sonar analysis from running when no token is set

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -34,6 +34,7 @@ jobs:
     - name: Build with Maven
       run: mvn --batch-mode --update-snapshots package --file pom.xml
     - name: Analyze with SonarCloud
+      if: env.SONAR_TOKEN != ''
       run: mvn --batch-mode sonar:sonar
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved the CI/CD workflow by adding a condition to the SonarCloud analysis job, ensuring it only runs when the necessary environment variable is set, preventing potential errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->