### PR TITLE
Update Majestik language grammar for boolean logic and conditionals

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ Components
 
 ----------
 Majestik is composed of two core components:
-2. Compiler: This component translates the AST produced by Magik-Tools' Magik-Squid into JVM bytecode using the Class-File API.
+1. Compiler: This component translates the AST produced by Magik-Tools' Magik-Squid into JVM bytecode using the Class-File API.
 
-   Currently, only supports literal types `string`, `integer` and `float`; as well as the `invoke` expressions.
-3. Runtime: provides a standard library with basic functionality to run a Magik program.
+   Currently, only supports literal types `boolean`, `string`, `integer` and `float`; as well as the `invoke` expressions.
+2. Runtime: provides a standard library with basic functionality to run a Magik program.
 
    As of now, only the `write` variable in the `sw` package has a barebones implementation.
 
@@ -31,6 +31,9 @@ _block
 
   flt << 5.4321
   write(flt)
+
+  bool << _true
+  write(bool)
 _endblock
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Components
 Majestik is composed of two core components:
 1. Compiler: This component translates the AST produced by Magik-Tools' Magik-Squid into JVM bytecode using the Class-File API.
 
-   Currently, only supports literal types `boolean`, `string`, `integer` and `float`; as well as the `invoke` expressions.
+   Currently, only supports literal types `boolean`, `string`, `integer` and `float`; as well as the `invoke` and the `if`/`then`/`else` expressions.
 2. Runtime: provides a standard library with basic functionality to run a Magik program.
 
    As of now, only the `write` variable in the `sw` package has a barebones implementation.
@@ -32,8 +32,13 @@ _block
   flt << 5.4321
   write(flt)
 
-  bool << _true
-  write(bool)
+  bool << _false
+  _if bool
+  _then
+    write("fail")
+  _else
+    write("success")
+  _endif
 _endblock
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Components
 
 ----------
 Majestik is composed of two core components:
+
 1. Compiler: This component translates the AST produced by Magik-Tools' Magik-Squid into JVM bytecode using the Class-File API.
 
    Currently, only supports literal types `boolean`, `string`, `integer` and `float`; as well as the `invoke` and the `if`/`then`/`else` expressions.

--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,7 @@
   <name>majestik</name>
   <url>http://www.keronic.com</url>
   <properties>
+    <dependency.junit.version>5.11.3</dependency.junit.version>
     <dependency.magik-tools.version>0.10.1</dependency.magik-tools.version>
     <maven.compiler.source>23</maven.compiler.source>
     <maven.compiler.target>23</maven.compiler.target>
@@ -23,14 +24,8 @@
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <version>5.11.3</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <version>5.14.2</version>
+      <artifactId>junit-jupiter-params</artifactId>
+      <version>${dependency.junit.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/com/keronic/majestik/ast/BooleanNode.java
+++ b/src/main/java/com/keronic/majestik/ast/BooleanNode.java
@@ -1,0 +1,38 @@
+package com.keronic.majestik.ast;
+
+import module java.base;
+
+import com.keronic.majestik.constant.ConstantDescs;
+
+public class BooleanNode extends Node {
+  private final boolean value;
+
+  public BooleanNode(boolean value) {
+    this.value = value;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    return switch (obj) {
+      case null -> false;
+      case BooleanNode other -> Objects.equals(this.value, other.value);
+      default -> false;
+    };
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(value);
+  }
+
+  @Override
+  public String toString() {
+    return String.format("BooleanNode{value='%s'}", value);
+  }
+
+  @Override
+  protected void doCompileInto(CodeBuilder cb) {
+    var bool = this.value ? "TRUE" : "FALSE";
+    cb.getstatic(ConstantDescs.CD_Boolean, bool, ConstantDescs.CD_Boolean);
+  }
+}

--- a/src/main/java/com/keronic/majestik/ast/BooleanNode.java
+++ b/src/main/java/com/keronic/majestik/ast/BooleanNode.java
@@ -27,7 +27,7 @@ public class BooleanNode extends Node {
 
   @Override
   public String toString() {
-    return String.format("BooleanNode{value='%s'}", value);
+    return String.format("BooleanNode{value=%s}", value);
   }
 
   @Override

--- a/src/main/java/com/keronic/majestik/ast/BooleanNode.java
+++ b/src/main/java/com/keronic/majestik/ast/BooleanNode.java
@@ -7,6 +7,11 @@ import com.keronic.majestik.constant.ConstantDescs;
 public class BooleanNode extends Node {
   private final boolean value;
 
+  /**
+   * Creates a new BooleanNode with the specified value.
+   *
+   * @param value the boolean value to be represented by this node
+   */
   public BooleanNode(boolean value) {
     this.value = value;
   }

--- a/src/main/java/com/keronic/majestik/ast/CompoundNode.java
+++ b/src/main/java/com/keronic/majestik/ast/CompoundNode.java
@@ -79,6 +79,6 @@ public class CompoundNode extends Node {
   }
 
   protected void doCompileInto(CodeBuilder cb) {
-    Arrays.stream(children).forEach(node -> node.compileInto(cb));
+    this.forEach(node -> node.compileInto(cb));
   }
 }

--- a/src/main/java/com/keronic/majestik/ast/CompoundNode.java
+++ b/src/main/java/com/keronic/majestik/ast/CompoundNode.java
@@ -74,6 +74,10 @@ public class CompoundNode extends Node {
     this.stream().forEach(action);
   }
 
+  public boolean isEmpty() {
+    return this.children.length == 0;
+  }
+
   protected void doCompileInto(CodeBuilder cb) {
     Arrays.stream(children).forEach(node -> node.compileInto(cb));
   }

--- a/src/main/java/com/keronic/majestik/ast/IfExpressionNode.java
+++ b/src/main/java/com/keronic/majestik/ast/IfExpressionNode.java
@@ -1,0 +1,49 @@
+package com.keronic.majestik.ast;
+
+import module java.base;
+
+import com.keronic.majestik.constant.ConstantDescs;
+
+/** IfExpressionNode */
+public class IfExpressionNode extends Node {
+  private final Node condition;
+  private final Node body;
+  private final Node elseBody;
+
+  public IfExpressionNode(Node condition, Node body, Node elseBody) {
+    this.condition = Objects.requireNonNull(condition);
+    this.body = Objects.requireNonNull(body);
+    this.elseBody = Objects.requireNonNull(elseBody);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    return switch (obj) {
+      case null -> false;
+      case IfExpressionNode other ->
+          Objects.equals(this.condition, other.condition)
+              && Objects.equals(this.body, other.body)
+              && Objects.equals(this.elseBody, other.elseBody);
+      default -> false;
+    };
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(this.condition, this.body, this.elseBody);
+  }
+
+  @Override
+  public String toString() {
+    return String.format(
+        "IfExpressionNode{condition=%s,body=%s,else=%s}", this.condition, this.body, this.elseBody);
+  }
+
+  @Override
+  protected void doCompileInto(CodeBuilder cb) {
+    this.condition.compileInto(cb);
+    cb.invokestatic(
+        ConstantDescs.CD_MagikObjectUtils, "should_be_boolean", ConstantDescs.MTD_booleanObject);
+    cb.ifThenElse(bcb -> this.body.compileInto(bcb), bcb -> this.elseBody.compileInto(bcb));
+  }
+}

--- a/src/main/java/com/keronic/majestik/ast/IfExpressionNode.java
+++ b/src/main/java/com/keronic/majestik/ast/IfExpressionNode.java
@@ -12,8 +12,8 @@ public class IfExpressionNode extends Node {
 
   public IfExpressionNode(Node condition, Node body, Node elseBody) {
     this.condition = Objects.requireNonNull(condition);
-    this.body = Objects.requireNonNull(body);
-    this.elseBody = Objects.requireNonNull(elseBody);
+    this.body = body != null ? body : new CompoundNode();
+    this.elseBody = elseBody != null ? elseBody : new CompoundNode();
   }
 
   @Override

--- a/src/main/java/com/keronic/majestik/ast/MajestikAbstractVisitor.java
+++ b/src/main/java/com/keronic/majestik/ast/MajestikAbstractVisitor.java
@@ -34,11 +34,14 @@ public abstract class MajestikAbstractVisitor<T> {
     if (nodeType instanceof MagikGrammar type) {
       return switch (type) {
         case ASSIGNMENT_EXPRESSION -> visitAssignmentExpression(node);
+        case FALSE -> visitFalse(node);
         case IDENTIFIER -> visitIdentifier(node);
+        case IF -> visitIfExpression(node);
         case MAGIK -> visitMagik(node);
         case NUMBER -> visitNumber(node);
         case PROCEDURE_INVOCATION -> visitProcedureInvocation(node);
         case STRING -> visitString(node);
+        case TRUE -> visitTrue(node);
         default -> visitDefault(node);
       };
     }
@@ -82,6 +85,10 @@ public abstract class MajestikAbstractVisitor<T> {
     return this.visitDefault(node);
   }
 
+  protected T visitFalse(final AstNode node) {
+    return this.visitDefault(node);
+  }
+
   /**
    * Visits an identifier node.
    *
@@ -89,6 +96,10 @@ public abstract class MajestikAbstractVisitor<T> {
    * @return result of the visit operation
    */
   protected T visitIdentifier(final AstNode node) {
+    return this.visitDefault(node);
+  }
+
+  protected T visitIfExpression(final AstNode node) {
     return this.visitDefault(node);
   }
 
@@ -105,6 +116,10 @@ public abstract class MajestikAbstractVisitor<T> {
   }
 
   protected T visitString(final AstNode node) {
+    return this.visitDefault(node);
+  }
+
+  protected T visitTrue(final AstNode node) {
     return this.visitDefault(node);
   }
 }

--- a/src/main/java/com/keronic/majestik/ast/MajestikAbstractVisitor.java
+++ b/src/main/java/com/keronic/majestik/ast/MajestikAbstractVisitor.java
@@ -85,6 +85,12 @@ public abstract class MajestikAbstractVisitor<T> {
     return this.visitDefault(node);
   }
 
+  /**
+   * Visits a false literal node.
+   *
+   * @param node the AST node representing the false literal
+   * @return result of the visit operation
+   */
   protected T visitFalse(final AstNode node) {
     return this.visitDefault(node);
   }
@@ -99,6 +105,12 @@ public abstract class MajestikAbstractVisitor<T> {
     return this.visitDefault(node);
   }
 
+  /**
+   * Visits an if expression node.
+   *
+   * @param node the AST node representing the if expression
+   * @return result of the visit operation
+   */
   protected T visitIfExpression(final AstNode node) {
     return this.visitDefault(node);
   }
@@ -119,6 +131,12 @@ public abstract class MajestikAbstractVisitor<T> {
     return this.visitDefault(node);
   }
 
+  /**
+   * Visits a true literal node.
+   *
+   * @param node the AST node representing the true literal
+   * @return result of the visit operation
+   */
   protected T visitTrue(final AstNode node) {
     return this.visitDefault(node);
   }

--- a/src/main/java/com/keronic/majestik/ast/NoOperationNode.java
+++ b/src/main/java/com/keronic/majestik/ast/NoOperationNode.java
@@ -10,7 +10,7 @@ import module java.base;
  * deliberately left empty.
  */
 public class NoOperationNode extends Node {
-  private final int HASHCODE = Objects.hashCode("nop");
+  private static final int NO_OPERATION_HASH = Objects.hashCode("nop");
 
   public NoOperationNode() {}
 
@@ -26,7 +26,7 @@ public class NoOperationNode extends Node {
 
   @Override
   public String toString() {
-    return String.format("NoOperationNode{}");
+    return "NoOperationNode{}";
   }
 
   @Override

--- a/src/main/java/com/keronic/majestik/ast/NoOperationNode.java
+++ b/src/main/java/com/keronic/majestik/ast/NoOperationNode.java
@@ -1,0 +1,28 @@
+package com.keronic.majestik.ast;
+
+import module java.base;
+
+public class NoOperationNode extends Node {
+
+  public NoOperationNode() {}
+
+  @Override
+  public boolean equals(Object obj) {
+    return obj instanceof NoOperationNode;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(null);
+  }
+
+  @Override
+  public String toString() {
+    return String.format("NoOperationNode{}");
+  }
+
+  @Override
+  protected void doCompileInto(CodeBuilder cb) {
+    cb.nop();
+  }
+}

--- a/src/main/java/com/keronic/majestik/ast/NoOperationNode.java
+++ b/src/main/java/com/keronic/majestik/ast/NoOperationNode.java
@@ -3,17 +3,18 @@ package com.keronic.majestik.ast;
 import module java.base;
 
 public class NoOperationNode extends Node {
+  private final int HASHCODE = Objects.hashCode("nop");
 
   public NoOperationNode() {}
 
   @Override
-  public boolean equals(Object obj) {
+  public boolean equals(final Object obj) {
     return obj instanceof NoOperationNode;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(null);
+    return HASHCODE;
   }
 
   @Override
@@ -22,7 +23,7 @@ public class NoOperationNode extends Node {
   }
 
   @Override
-  protected void doCompileInto(CodeBuilder cb) {
+  protected void doCompileInto(final CodeBuilder cb) {
     cb.nop();
   }
 }

--- a/src/main/java/com/keronic/majestik/ast/NoOperationNode.java
+++ b/src/main/java/com/keronic/majestik/ast/NoOperationNode.java
@@ -2,6 +2,13 @@ package com.keronic.majestik.ast;
 
 import module java.base;
 
+/**
+ * Represents a no-operation node in the abstract syntax tree (AST) of the Majestik language. This
+ * node serves as a placeholder or signifies an intentional absence of operation. When compiled, it
+ * generates a NOP (no-operation) instruction in the bytecode, effectively doing nothing during
+ * execution. This can be useful for maintaining consistent control flow or when an operation is
+ * deliberately left empty.
+ */
 public class NoOperationNode extends Node {
   private final int HASHCODE = Objects.hashCode("nop");
 

--- a/src/main/java/com/keronic/majestik/ast/NoOperationNode.java
+++ b/src/main/java/com/keronic/majestik/ast/NoOperationNode.java
@@ -21,7 +21,7 @@ public class NoOperationNode extends Node {
 
   @Override
   public int hashCode() {
-    return HASHCODE;
+    return NO_OPERATION_HASH;
   }
 
   @Override

--- a/src/main/java/com/keronic/majestik/constant/ConstantDescs.java
+++ b/src/main/java/com/keronic/majestik/constant/ConstantDescs.java
@@ -8,11 +8,13 @@ public final class ConstantDescs {
   // @see java.base/java.lang.constant.ConstantDescs#CLASS_INIT_NAME
   public static final String CLASS_INIT_NAME = java.lang.constant.ConstantDescs.CLASS_INIT_NAME;
 
+  public static final ClassDesc CD_boolean = java.lang.constant.ConstantDescs.CD_boolean;
 	public static final ClassDesc CD_double = java.lang.constant.ConstantDescs.CD_double;
   public static final ClassDesc CD_int = java.lang.constant.ConstantDescs.CD_int;
 	public static final ClassDesc CD_long = java.lang.constant.ConstantDescs.CD_long;
   public static final ClassDesc CD_void = java.lang.constant.ConstantDescs.CD_void;
 
+  public static final ClassDesc CD_Boolean = java.lang.constant.ConstantDescs.CD_Boolean;
 	public static final ClassDesc CD_CallSite = java.lang.constant.ConstantDescs.CD_CallSite;
   public static final ClassDesc CD_Class = java.lang.constant.ConstantDescs.CD_Class;
 	public static final ClassDesc CD_Double = java.lang.constant.ConstantDescs.CD_Double;
@@ -31,18 +33,19 @@ public final class ConstantDescs {
       ClassDesc.of("com.keronic.majestik.language.invokers.DynamicAccessor");
   public static final ClassDesc CD_GlobalAccessor =
       ClassDesc.of("com.keronic.majestik.language.invokers.GlobalAccessor");
+  public static final ClassDesc CD_MagikObjectUtils =
+      ClassDesc.of("com.keronic.majestik.language.utils.MagikObjectUtils");
   public static final ClassDesc CD_ProcInvoker =
       ClassDesc.of("com.keronic.majestik.language.invokers.ProcInvoker");
   public static final ClassDesc CD_TupleBuilder =
       ClassDesc.of("com.keronic.majestik.language.invokers.TupleBuilder");
 
-  public static final DirectMethodHandleDesc DYNAMIC_STORER_BSM =
-      java.lang.constant.ConstantDescs.ofCallsiteBootstrap(
-          CD_DynamicAccessor, "bootstrapStorer", CD_CallSite, CD_String);
-
   public static final DirectMethodHandleDesc BSM_BINARY_DISPATCHER =
       java.lang.constant.ConstantDescs.ofCallsiteBootstrap(
           CD_BinaryDispatcher, "bootstrap", CD_CallSite);
+  public static final DirectMethodHandleDesc BSM_DYNAMIC_STORER =
+      java.lang.constant.ConstantDescs.ofCallsiteBootstrap(
+          CD_DynamicAccessor, "bootstrapStorer", CD_CallSite, CD_String);
   public static final DirectMethodHandleDesc BSM_GLOBAL_FETCHER =
       java.lang.constant.ConstantDescs.ofCallsiteBootstrap(
           CD_GlobalAccessor, "bootstrapFetcher2", CD_CallSite, CD_String, CD_String);
@@ -73,6 +76,8 @@ public final class ConstantDescs {
 
   public static final MethodTypeDesc MTD_void = java.lang.constant.ConstantDescs.MTD_void;
 
+  public static final MethodTypeDesc MTD_booleanObject =
+      MethodTypeDesc.of(ConstantDescs.CD_boolean, ConstantDescs.CD_Object);
   public static final MethodTypeDesc MTD_Doubledouble =
       MethodTypeDesc.of(ConstantDescs.CD_Double, ConstantDescs.CD_double);
   public static final MethodTypeDesc MTD_Longlong =

--- a/src/main/java/com/keronic/majestik/language/utils/MagikObjectUtils.java
+++ b/src/main/java/com/keronic/majestik/language/utils/MagikObjectUtils.java
@@ -1,0 +1,21 @@
+package com.keronic.majestik.language.utils;
+
+import com.keronic.majestik.MajestikRuntimeException;
+
+public class MagikObjectUtils {
+
+  @SuppressWarnings("java:S100")
+  public static boolean should_be_boolean(Object value) {
+    try {
+      var bool = (Boolean) value;
+
+      return bool.booleanValue();
+    } catch (Exception e) {
+
+      throw new MajestikRuntimeException(e);
+    }
+  }
+
+  /** Private constructor to prevent instantiation. */
+  private MagikObjectUtils() {}
+}

--- a/src/test/java/com/keronic/MajestikClassLoaderTest.java
+++ b/src/test/java/com/keronic/MajestikClassLoaderTest.java
@@ -2,7 +2,9 @@ package com.keronic;
 
 import module java.base;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.keronic.majestik.constant.ConstantDescs;
 import org.junit.jupiter.api.AfterEach;
@@ -35,11 +37,11 @@ class MajestikClassLoaderTest {
             clb ->
                 clb.withMethodBody(
                     ConstantDescs.INIT_NAME,
-                        ConstantDescs.MTD_void,
-                        ClassFile.ACC_PUBLIC,
-                        cb ->
-                            cb.aload(0)
-                                .invokespecial(
+                    ConstantDescs.MTD_void,
+                    ClassFile.ACC_PUBLIC,
+                    cb ->
+                        cb.aload(0)
+                            .invokespecial(
                                 ConstantDescs.CD_Object,
                                 ConstantDescs.INIT_NAME,
                                 ConstantDescs.MTD_void)
@@ -69,9 +71,9 @@ class MajestikClassLoaderTest {
           classLoader.findClass("magik.Q.NonExistingClass");
         });
     assertThrows(
-	    ClassNotFoundException.class,
-	    () -> {
-	      classLoader.findClass("com.example.NonExistingClass");
+        ClassNotFoundException.class,
+        () -> {
+          classLoader.findClass("com.example.NonExistingClass");
         });
   }
 }

--- a/src/test/java/com/keronic/PathUtilsTest.java
+++ b/src/test/java/com/keronic/PathUtilsTest.java
@@ -7,7 +7,8 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for the PathUtils class, focusing on path manipulation and file extension handling
- * functionality.
+ * functionality (e.g., extracting base names from files with single/double extensions,
+ * handling special cases like empty strings and spaces).
  */
 class PathUtilsTest {
   @Test

--- a/src/test/java/com/keronic/PathUtilsTest.java
+++ b/src/test/java/com/keronic/PathUtilsTest.java
@@ -1,13 +1,13 @@
 /** */
 package com.keronic;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
 
 /**
- * Unit tests for the PathUtils class, focusing on path manipulation
- * and file extension handling functionality.
+ * Unit tests for the PathUtils class, focusing on path manipulation and file extension handling
+ * functionality.
  */
 class PathUtilsTest {
   @Test

--- a/src/test/java/com/keronic/majestik/ast/AssignmentNodeTest.java
+++ b/src/test/java/com/keronic/majestik/ast/AssignmentNodeTest.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import org.junit.jupiter.api.Test;
 
-class AssignmentNodeTest {
+class AssignmentNodeTest extends NodeTest {
   @Test
   void testEquals() {
     var node1 = new AssignmentNode(new CompoundNode(), new CompoundNode());
@@ -14,7 +14,7 @@ class AssignmentNodeTest {
     assertEquals(node1, node2);
 
     assertNotEquals(node1, new CompoundNode());
-    assertNotEquals(node2, null);
+    assertNotEqualsNull(node2);
   }
 
   @Test

--- a/src/test/java/com/keronic/majestik/ast/BooleanNodeTest.java
+++ b/src/test/java/com/keronic/majestik/ast/BooleanNodeTest.java
@@ -6,7 +6,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.provider.CsvSource;
 
 class BooleanNodeTest extends NodeTest {
   @Test
@@ -70,11 +72,8 @@ class BooleanNodeTest extends NodeTest {
   }
 
   @ParameterizedTest
-  @CsvSource({
-      "true,  BooleanNode{value=true}",
-      "false, BooleanNode{value=false}"
-  })
+  @CsvSource({"true,  BooleanNode{value=true}", "false, BooleanNode{value=false}"})
   void testToString(boolean input, String expected) {
-      assertEquals(expected, new BooleanNode(input).toString());
+    assertEquals(expected, new BooleanNode(input).toString());
   }
 }

--- a/src/test/java/com/keronic/majestik/ast/BooleanNodeTest.java
+++ b/src/test/java/com/keronic/majestik/ast/BooleanNodeTest.java
@@ -67,4 +67,10 @@ class BooleanNodeTest extends NodeTest {
     assertEquals("java/lang/Boolean", falsefis.owner().name().toString());
     assertEquals("FALSE", falsefis.name().toString());
   }
+
+  @Test
+  void testToString() {
+    assertEquals("BooleanNode{value=true}", new BooleanNode(true).toString());
+    assertEquals("BooleanNode{value=false}", new BooleanNode(false).toString());
+  }
 }

--- a/src/test/java/com/keronic/majestik/ast/BooleanNodeTest.java
+++ b/src/test/java/com/keronic/majestik/ast/BooleanNodeTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 class BooleanNodeTest extends NodeTest {

--- a/src/test/java/com/keronic/majestik/ast/BooleanNodeTest.java
+++ b/src/test/java/com/keronic/majestik/ast/BooleanNodeTest.java
@@ -46,6 +46,14 @@ class BooleanNodeTest extends NodeTest {
     var node1 = new BooleanNode(true);
     var node2 = new BooleanNode(true);
     var node3 = new BooleanNode(false);
+
+    // Test consistency
+    assertEquals(node1.hashCode(), node1.hashCode(), "Hash code should be consistent");
+
+    // Test with compound expression
+    var compound = new CompoundNode(node1, node2);
+    assertNotEquals(node1.hashCode(), compound.hashCode());
+
     assertEquals(node1.hashCode(), node2.hashCode());
 
     // Test inequality

--- a/src/test/java/com/keronic/majestik/ast/BooleanNodeTest.java
+++ b/src/test/java/com/keronic/majestik/ast/BooleanNodeTest.java
@@ -1,0 +1,70 @@
+package com.keronic.majestik.ast;
+
+import module java.base;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import org.junit.jupiter.api.Test;
+
+class BooleanNodeTest extends NodeTest {
+  @Test
+  void shouldBeEqualWhenValuesAreTheSame() {
+    var node1 = new BooleanNode(true);
+    var node2 = new BooleanNode(true);
+    var node3 = new BooleanNode(true);
+    var node4 = new BooleanNode(false);
+
+    // Equality
+    assertEquals(node1, node2);
+
+    // Reflexivity
+    assertEquals(node1, node1);
+
+    // Symmetry
+    assertEquals(node1, node2);
+    assertEquals(node2, node1);
+
+    // Transitivity
+    assertEquals(node1, node2);
+    assertEquals(node2, node3);
+    assertEquals(node1, node3);
+
+    // Inequality
+    assertNotEquals(node1, true);
+    assertNotEquals(node1, node4);
+    assertNotEqualsNull(node4);
+  }
+
+  @Test
+  void shouldHaveSameHashCodeWhenValuesAreEqual() {
+    var node1 = new BooleanNode(true);
+    var node2 = new BooleanNode(true);
+    var node3 = new BooleanNode(false);
+    assertEquals(node1.hashCode(), node2.hashCode());
+
+    // Test inequality
+    assertNotEquals(node1.hashCode(), node3.hashCode());
+  }
+
+  @Test
+  void shouldGenerateFieldInstructions() {
+    var cnode = new CompoundNode(new BooleanNode(true), new BooleanNode(false));
+    var code = this.compileInto(cnode::compileInto);
+
+    assertEquals(2, code.elementList().size());
+    var trueinstruction = code.elementList().get(0);
+    var falseinstruction = code.elementList().get(1);
+    assertInstanceOf(FieldInstruction.class, trueinstruction);
+    assertInstanceOf(FieldInstruction.class, falseinstruction);
+    var truefis = (FieldInstruction) trueinstruction;
+    var falsefis = (FieldInstruction) falseinstruction;
+
+    // Verify instruction properties
+    assertEquals("java/lang/Boolean", truefis.owner().name().toString());
+    assertEquals("TRUE", truefis.name().toString());
+    assertEquals("java/lang/Boolean", falsefis.owner().name().toString());
+    assertEquals("FALSE", falsefis.name().toString());
+  }
+}

--- a/src/test/java/com/keronic/majestik/ast/BooleanNodeTest.java
+++ b/src/test/java/com/keronic/majestik/ast/BooleanNodeTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 
 class BooleanNodeTest extends NodeTest {
   @Test
+  @DisplayName("Boolean node equality tests")
   void shouldBeEqualWhenValuesAreTheSame() {
     var node1 = new BooleanNode(true);
     var node2 = new BooleanNode(true);
@@ -68,9 +69,12 @@ class BooleanNodeTest extends NodeTest {
     assertEquals("FALSE", falsefis.name().toString());
   }
 
-  @Test
-  void testToString() {
-    assertEquals("BooleanNode{value=true}", new BooleanNode(true).toString());
-    assertEquals("BooleanNode{value=false}", new BooleanNode(false).toString());
+  @ParameterizedTest
+  @CsvSource({
+      "true,  BooleanNode{value=true}",
+      "false, BooleanNode{value=false}"
+  })
+  void testToString(boolean input, String expected) {
+      assertEquals(expected, new BooleanNode(input).toString());
   }
 }

--- a/src/test/java/com/keronic/majestik/ast/CompoundNodeTest.java
+++ b/src/test/java/com/keronic/majestik/ast/CompoundNodeTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
  * Unit tests for CompoundNode class, verifying equality and hash code functionality for AST
  * compound nodes.
  */
-class CompoundNodeTest {
+class CompoundNodeTest extends NodeTest {
   @Test
   void testEquals() {
     // Test empty nodes
@@ -44,7 +44,7 @@ class CompoundNodeTest {
     assertNotEquals(node1, node3);
 
     // Test inequality with null
-    assertNotEquals(node1, null);
+    assertNotEqualsNull(node1);
 
     // Test inequality with different type
     assertNotEquals(node1, new NumberNode(5));

--- a/src/test/java/com/keronic/majestik/ast/IdentifierNodeTest.java
+++ b/src/test/java/com/keronic/majestik/ast/IdentifierNodeTest.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
-class IdentifierNodeTest {
+class IdentifierNodeTest extends NodeTest {
   @Test
   void testEquals() {
     var node1 = new IdentifierNode("var");
@@ -27,7 +27,7 @@ class IdentifierNodeTest {
     assertEquals(node1, node4);
 
     assertNotEquals(node1, node3);
-    assertNotEquals(node2, null);
+    assertNotEqualsNull(node2);
     assertNotEquals(node3, new StringNode("other"));
 
     // Verify equals-hashCode contract

--- a/src/test/java/com/keronic/majestik/ast/IfExpressionNodeTest.java
+++ b/src/test/java/com/keronic/majestik/ast/IfExpressionNodeTest.java
@@ -6,10 +6,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 class IfExpressionNodeTest extends NodeTest {
-  @Test
   @Test
   @DisplayName("If expression node equality tests")
   void shouldBeEqualWhenValuesAreTheSame() {

--- a/src/test/java/com/keronic/majestik/ast/IfExpressionNodeTest.java
+++ b/src/test/java/com/keronic/majestik/ast/IfExpressionNodeTest.java
@@ -83,8 +83,10 @@ class IfExpressionNodeTest extends NodeTest {
 
     var branch0 = (BranchInstruction) cel[2];
     assertEquals(cel[5], branch0.target());
+    assertEquals(Opcode.IFEQ, branch0.opcode());
 
     var branch1 = (BranchInstruction) cel[4];
     assertEquals(cel[7], branch1.target());
+    assertEquals(Opcode.GOTO, branch1.opcode());
   }
 }

--- a/src/test/java/com/keronic/majestik/ast/IfExpressionNodeTest.java
+++ b/src/test/java/com/keronic/majestik/ast/IfExpressionNodeTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import org.junit.jupiter.api.Test;
 
 class IfExpressionNodeTest extends NodeTest {
+  @Test
   void shouldBeEqualWhenValuesAreTheSame() {
     var node1 = new IfExpressionNode(new BooleanNode(true), new CompoundNode(), new CompoundNode());
     var node2 = new IfExpressionNode(new BooleanNode(true), new CompoundNode(), new CompoundNode());

--- a/src/test/java/com/keronic/majestik/ast/IfExpressionNodeTest.java
+++ b/src/test/java/com/keronic/majestik/ast/IfExpressionNodeTest.java
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.Test;
 
 class IfExpressionNodeTest extends NodeTest {
   @Test
+  @Test
+  @DisplayName("If expression node equality tests")
   void shouldBeEqualWhenValuesAreTheSame() {
     var node1 = new IfExpressionNode(new BooleanNode(true), new CompoundNode(), new CompoundNode());
     var node2 = new IfExpressionNode(new BooleanNode(true), new CompoundNode(), new CompoundNode());

--- a/src/test/java/com/keronic/majestik/ast/IfExpressionNodeTest.java
+++ b/src/test/java/com/keronic/majestik/ast/IfExpressionNodeTest.java
@@ -44,10 +44,15 @@ class IfExpressionNodeTest extends NodeTest {
     var node2 = new IfExpressionNode(new BooleanNode(true), new CompoundNode(), new CompoundNode());
     var node3 =
         new IfExpressionNode(new BooleanNode(false), new CompoundNode(), new CompoundNode());
+    var node4 =
+        new IfExpressionNode(new BooleanNode(true), new NumberNode(42), new StringNode("else"));
     assertEquals(node1.hashCode(), node2.hashCode());
 
     // Test inequality
     assertNotEquals(node1.hashCode(), node3.hashCode());
+
+    // Test hash code consistency
+    assertEquals(node4.hashCode(), node4.hashCode(), "Hash code should be consistent");
   }
 
   @Test

--- a/src/test/java/com/keronic/majestik/ast/IfExpressionNodeTest.java
+++ b/src/test/java/com/keronic/majestik/ast/IfExpressionNodeTest.java
@@ -1,0 +1,48 @@
+package com.keronic.majestik.ast;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import org.junit.jupiter.api.Test;
+
+class IfExpressionNodeTest extends NodeTest {
+  void shouldBeEqualWhenValuesAreTheSame() {
+    var node1 = new IfExpressionNode(new BooleanNode(true), new CompoundNode(), new CompoundNode());
+    var node2 = new IfExpressionNode(new BooleanNode(true), new CompoundNode(), new CompoundNode());
+    var node3 = new IfExpressionNode(new BooleanNode(true), new CompoundNode(), new CompoundNode());
+    var node4 =
+        new IfExpressionNode(new BooleanNode(false), new CompoundNode(), new CompoundNode());
+
+    // Equality
+    assertEquals(node1, node2);
+
+    // Reflexivity
+    assertEquals(node1, node1);
+
+    // Symmetry
+    assertEquals(node1, node2);
+    assertEquals(node2, node1);
+
+    // Transitivity
+    assertEquals(node1, node2);
+    assertEquals(node2, node3);
+    assertEquals(node1, node3);
+
+    // Inequality
+    assertNotEquals(node1, true);
+    assertNotEquals(node1, node4);
+    assertNotEqualsNull(node4);
+  }
+
+  @Test
+  void shouldHaveSameHashCodeWhenValuesAreEqual() {
+    var node1 = new IfExpressionNode(new BooleanNode(true), new CompoundNode(), new CompoundNode());
+    var node2 = new IfExpressionNode(new BooleanNode(true), new CompoundNode(), new CompoundNode());
+    var node3 =
+        new IfExpressionNode(new BooleanNode(false), new CompoundNode(), new CompoundNode());
+    assertEquals(node1.hashCode(), node2.hashCode());
+
+    // Test inequality
+    assertNotEquals(node1.hashCode(), node3.hashCode());
+  }
+}

--- a/src/test/java/com/keronic/majestik/ast/InvocationNodeTest.java
+++ b/src/test/java/com/keronic/majestik/ast/InvocationNodeTest.java
@@ -2,18 +2,20 @@ package com.keronic.majestik.ast;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
 import org.junit.jupiter.api.Test;
 
 class InvocationNodeTest {
   /**
-   * Verifies that InvocationNode instances with identical CompoundNode contents are considered equal.
-   * Tests both empty CompoundNode and CompoundNode with a single NumberNode.
+   * Verifies that InvocationNode instances with identical CompoundNode contents are considered
+   * equal. Tests both empty CompoundNode and CompoundNode with a single NumberNode.
    */
   @Test
   void shouldConsiderInvocationNodesWithIdenticalCompoundNodesEqual() {
     assertEquals(new InvocationNode(new CompoundNode()), new InvocationNode(new CompoundNode()));
-    assertEquals(new InvocationNode(new CompoundNode(new NumberNode(0))),
-      new InvocationNode(new CompoundNode(new NumberNode(0))));
+    assertEquals(
+        new InvocationNode(new CompoundNode(new NumberNode(0))),
+        new InvocationNode(new CompoundNode(new NumberNode(0))));
   }
 
   @Test
@@ -25,7 +27,8 @@ class InvocationNodeTest {
 
   @Test
   void testHashcode() {
-    assertEquals(new InvocationNode(new CompoundNode()).hashCode(),
-      new InvocationNode(new CompoundNode()).hashCode());
+    assertEquals(
+        new InvocationNode(new CompoundNode()).hashCode(),
+        new InvocationNode(new CompoundNode()).hashCode());
   }
 }

--- a/src/test/java/com/keronic/majestik/ast/MajestikCodeVisitorTest.java
+++ b/src/test/java/com/keronic/majestik/ast/MajestikCodeVisitorTest.java
@@ -53,6 +53,25 @@ class MajestikCodeVisitorTest {
   }
 
   @Test
+  void testVisitIfExpression() {
+    // Test input
+    var mcv = new MajestikCodeVisitor();
+    var mf = new MagikFile(MagikFile.DEFAULT_URI, ("_if _true _then _else _endif%n").formatted());
+
+    // Execute
+    var node = mcv.scanFile(mf);
+
+    // Verify
+    assertNotNull(node, "Result should not be null");
+    assertInstanceOf(CompoundNode.class, node, "Expected CompoundNode");
+    var cnode = (CompoundNode) node;
+    assertEquals(1, cnode.getChildCount(), "Expected one branch node");
+    var child0 = cnode.getChild(0);
+    assertInstanceOf(IfExpressionNode.class, child0, "First child should be IfExpressionNode");
+  }
+
+
+  @Test
   void testVisitInvoke() {
     var mcv = new MajestikCodeVisitor();
     var mf = new MagikFile(MagikFile.DEFAULT_URI, ("write(0)%n").formatted());

--- a/src/test/java/com/keronic/majestik/ast/MajestikCodeVisitorTest.java
+++ b/src/test/java/com/keronic/majestik/ast/MajestikCodeVisitorTest.java
@@ -13,10 +13,10 @@ import org.junit.jupiter.api.Test;
  */
 class MajestikCodeVisitorTest {
   @Test
-  void testVisitString() {
+  void testVisitBoolean() {
     // Test input
     var mcv = new MajestikCodeVisitor();
-    var mf = new MagikFile(MagikFile.DEFAULT_URI, ("\"string1\"%n'string2'%n").formatted());
+    var mf = new MagikFile(MagikFile.DEFAULT_URI, ("_true%n" + "_false%n").formatted());
 
     // Execute
     var node = mcv.scanFile(mf);
@@ -28,10 +28,10 @@ class MajestikCodeVisitorTest {
     assertEquals(2, cnode.getChildCount(), "Expected two string nodes");
     var child0 = cnode.getChild(0);
     var child1 = cnode.getChild(1);
-    assertInstanceOf(StringNode.class, child0, "First child should be StringNode");
-    assertInstanceOf(StringNode.class, child1, "Second child should be StringNode");
-    assertEquals(new StringNode("string1"), (StringNode) child0);
-    assertEquals(new StringNode("string2"), (StringNode) child1);
+    assertInstanceOf(BooleanNode.class, child0, "First child should be StringNode");
+    assertInstanceOf(BooleanNode.class, child1, "Second child should be StringNode");
+    assertEquals(new BooleanNode(true), child0);
+    assertEquals(new BooleanNode(false), child1);
   }
 
   @Test
@@ -71,7 +71,31 @@ class MajestikCodeVisitorTest {
     var expectedInvocation = new InvocationNode(new CompoundNode(new NumberNode(0)));
     var actualInvocation = n.getChild(1);
     assertInstanceOf(InvocationNode.class, actualInvocation, "Expected InvocationNode");
-    assertEquals(expectedInvocation.hashCode(), actualInvocation.hashCode(), 
+    assertEquals(
+        expectedInvocation.hashCode(),
+        actualInvocation.hashCode(),
         "Expected matching invocation nodes");
+  }
+
+  @Test
+  void testVisitString() {
+    // Test input
+    var mcv = new MajestikCodeVisitor();
+    var mf = new MagikFile(MagikFile.DEFAULT_URI, ("\"string1\"%n" + "'string2'%n").formatted());
+
+    // Execute
+    var node = mcv.scanFile(mf);
+
+    // Verify
+    assertNotNull(node, "Result should not be null");
+    assertInstanceOf(CompoundNode.class, node, "Expected CompoundNode");
+    var cnode = (CompoundNode) node;
+    assertEquals(2, cnode.getChildCount(), "Expected two string nodes");
+    var child0 = cnode.getChild(0);
+    var child1 = cnode.getChild(1);
+    assertInstanceOf(StringNode.class, child0, "First child should be StringNode");
+    assertInstanceOf(StringNode.class, child1, "Second child should be StringNode");
+    assertEquals(new StringNode("string1"), child0);
+    assertEquals(new StringNode("string2"), child1);
   }
 }

--- a/src/test/java/com/keronic/majestik/ast/NoOperationNodeTest.java
+++ b/src/test/java/com/keronic/majestik/ast/NoOperationNodeTest.java
@@ -1,0 +1,60 @@
+package com.keronic.majestik.ast;
+
+import module java.base;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import org.junit.jupiter.api.Test;
+
+class NoOperationNodeTest extends NodeTest {
+  @Test
+  void shouldBeEqualWhenValuesAreTheSame() {
+    var node1 = new NoOperationNode();
+    var node2 = new NoOperationNode();
+    var node3 = new NoOperationNode();
+
+    // Equality
+    assertEquals(node1, node2);
+
+    // Reflexivity
+    assertEquals(node1, node1);
+
+    // Symmetry
+    assertEquals(node1, node2);
+    assertEquals(node2, node1);
+
+    // Transitivity
+    assertEquals(node1, node2);
+    assertEquals(node2, node3);
+    assertEquals(node1, node3);
+
+    // Inequality
+    assertNotEquals(node1, true);
+    assertNotEqualsNull(node1);
+  }
+
+  @Test
+  void shouldHaveSameHashCodeWhenValuesAreEqual() {
+    var node1 = new NoOperationNode();
+    var node2 = new NoOperationNode();
+    assertEquals(node1.hashCode(), node2.hashCode());
+  }
+
+  @Test
+  void shouldGenerateNopInstruction() {
+    var cnode = new NoOperationNode();
+    var code = this.compileInto(cnode::compileInto);
+
+    assertEquals(1, code.elementList().size());
+    var cel = code.elementList().getFirst();
+
+    assertInstanceOf(NopInstruction.class, cel);
+  }
+
+  @Test
+  void testToString() {
+    assertEquals("NoOperationNode{}", new NoOperationNode().toString());
+  }
+}

--- a/src/test/java/com/keronic/majestik/ast/NoOperationNodeTest.java
+++ b/src/test/java/com/keronic/majestik/ast/NoOperationNodeTest.java
@@ -8,6 +8,9 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import org.junit.jupiter.api.Test;
 
+/**
+ * Unit tests for {@link NoOperationNode} class.
+ */
 class NoOperationNodeTest extends NodeTest {
   @Test
   void shouldBeEqualWhenValuesAreTheSame() {

--- a/src/test/java/com/keronic/majestik/ast/NodeTest.java
+++ b/src/test/java/com/keronic/majestik/ast/NodeTest.java
@@ -8,7 +8,17 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
-/** Provides utility methods for testing AST node compilation into bytecode. */
+/**
+ * Base test class providing common utilities and assertions for AST node tests.
+ *
+ * <p>The {@code NodeTest} class offers shared helper methods and custom assertion utilities that
+ * are used across various AST node test cases. By extending this class, individual node test
+ * classes can leverage common functionality, ensure consistency, and reduce code duplication in
+ * tests.
+ *
+ * <p>Notably, this class includes methods like {@link #assertNotEqualsNull(Object)}, which provides
+ * a standardized way to assert that objects are not equal to {@code null}.
+ */
 abstract class NodeTest {
   /**
    * Compiles a code builder consumer into a CodeModel for testing.

--- a/src/test/java/com/keronic/majestik/ast/NodeTest.java
+++ b/src/test/java/com/keronic/majestik/ast/NodeTest.java
@@ -39,6 +39,12 @@ abstract class NodeTest {
     return code;
   }
 
+  /**
+   * Asserts that the provided object is not equal to null.
+   *
+   * @param actual the object to test
+   * @throws AssertionError if actual equals null
+   */
   public static void assertNotEqualsNull(Object actual) {
     assertNotEquals(actual, null);
   }

--- a/src/test/java/com/keronic/majestik/ast/NodeTest.java
+++ b/src/test/java/com/keronic/majestik/ast/NodeTest.java
@@ -6,10 +6,9 @@ import static java.lang.classfile.ClassFile.ACC_PUBLIC;
 import static java.lang.classfile.ClassFile.ACC_STATIC;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
-/**
- * Provides utility methods for testing AST node compilation into bytecode.
- */
+/** Provides utility methods for testing AST node compilation into bytecode. */
 abstract class NodeTest {
   /**
    * Compiles a code builder consumer into a CodeModel for testing.
@@ -38,5 +37,9 @@ abstract class NodeTest {
     var code = cm.methods().getFirst().code().orElseThrow();
     assertInstanceOf(CodeModel.class, code, "Generated code should be an instance of CodeModel");
     return code;
+  }
+
+  public static void assertNotEqualsNull(Object actual) {
+    assertNotEquals(actual, null);
   }
 }

--- a/src/test/java/com/keronic/majestik/ast/NumberNodeTest.java
+++ b/src/test/java/com/keronic/majestik/ast/NumberNodeTest.java
@@ -12,9 +12,6 @@ import org.junit.jupiter.api.Test;
 
 class NumberNodeTest extends NodeTest {
   @Test
-  // Suppressed "Assertion arguments should be passed in the correct order" as the expected/actual
-  // order is clear in this context
-  @SuppressWarnings("java:S3415")
   void shouldBeEqualWhenValuesAreTheSame() {
     var node1 = new NumberNode(5);
     var node2 = new NumberNode(5);
@@ -25,7 +22,7 @@ class NumberNodeTest extends NodeTest {
     var node3 = new NumberNode(10);
     assertNotEquals(node1, node3);
     var node4 = new NumberNode(0);
-    assertNotEquals(node4, null);
+    assertNotEqualsNull(node4);
   }
 
   @Test

--- a/src/test/java/com/keronic/majestik/ast/StringNodeTest.java
+++ b/src/test/java/com/keronic/majestik/ast/StringNodeTest.java
@@ -10,9 +10,6 @@ import org.junit.jupiter.api.Test;
 
 class StringNodeTest extends NodeTest {
   @Test
-  // Suppressing "Assertion arguments should be passed in the correct order" as the expected/actual
-  // order is correct here
-  @SuppressWarnings("java:S3415")
   void shouldBeEqualWhenValuesAreTheSame() {
     var node1 = new StringNode("string1");
     var node2 = new StringNode("string1");
@@ -24,24 +21,24 @@ class StringNodeTest extends NodeTest {
     var node3 = new StringNode("String2");
     assertNotEquals(node1, node3);
     var node4 = new StringNode("");
-    assertNotEquals(node4, null);
+    assertNotEqualsNull(node4);
   }
 
   @Test
   void shouldHaveSameHashCodeWhenValuesAreEqual() {
     var node1 = new StringNode("string2");
     var node2 = new StringNode("string2");
-    
+
     // Test consistency
     int hash1 = node1.hashCode();
     assertEquals(hash1, node1.hashCode(), "hashCode should be consistent");
-    
+
     // Test equality contract
     assertEquals(node1.hashCode(), node2.hashCode(), "Equal objects should have equal hashCodes");
-    
+
     // Verify hashCode/equals consistency
     if (node1.equals(node2)) {
-        assertEquals(node1.hashCode(), node2.hashCode(), "Equal objects must have equal hashCodes");
+      assertEquals(node1.hashCode(), node2.hashCode(), "Equal objects must have equal hashCodes");
     }
   }
 

--- a/src/test/java/com/keronic/majestik/language/ResultTupleTest.java
+++ b/src/test/java/com/keronic/majestik/language/ResultTupleTest.java
@@ -1,6 +1,8 @@
 package com.keronic.majestik.language;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import org.junit.jupiter.api.Test;
 
@@ -10,19 +12,19 @@ class ResultTupleTest {
   private Object[] elems = new Object[] {"Str", "ing"};
 
   @Test
-  void testEquals() throws Throwable {
+  void testEquals() {
     assertEquals(rs1, rs2);
     assertNotEquals(rs1, elems);
   }
 
   @Test
-  void testHashcode() throws Throwable {
+  void testHashcode() {
     assertEquals(rs1.hashCode(), rs2.hashCode());
     assertNotEquals(rs1.hashCode(), elems.hashCode());
   }
 
   @Test
-  void testEmptyTuple() throws Throwable {
+  void testEmptyTuple() {
     assertSame(ResultTuple.create(), ResultTuple.create());
   }
 }

--- a/src/test/java/com/keronic/majestik/language/ResultTupleTest.java
+++ b/src/test/java/com/keronic/majestik/language/ResultTupleTest.java
@@ -1,8 +1,7 @@
-package com.keronic.language;
+package com.keronic.majestik.language;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.keronic.majestik.language.ResultTuple;
 import org.junit.jupiter.api.Test;
 
 class ResultTupleTest {

--- a/src/test/java/com/keronic/majestik/language/invokers/BinaryDispatcherTest.java
+++ b/src/test/java/com/keronic/majestik/language/invokers/BinaryDispatcherTest.java
@@ -1,4 +1,4 @@
-package com.keronic.language.invokers;
+package com.keronic.majestik.language.invokers;
 
 import module java.base;
 
@@ -9,42 +9,42 @@ import static org.junit.jupiter.api.Assertions.*;
 import com.keronic.majestik.constant.ConstantDescs;
 import org.junit.jupiter.api.Test;
 
-class DynamicAccessorTest {
+class BinaryDispatcherTest {
+  private static final String TEST_PACKAGE = BinaryDispatcherTest.class.getPackageName();
+  private static final String TEST_CLASS = TEST_PACKAGE + ".C";
+
   /**
    * @throws Throwable
    */
   @Test
-  void testStoreDynamic() throws Throwable {
-    var mt = MethodType.methodType(Object.class);
+  void testLongPlusLong() throws Throwable {
+    var mt = MethodType.methodType(Long.class, Long.class, Long.class);
     var mtd = mt.describeConstable().get();
-    var globalname = "!_test_!";
-    var packagename = "user";
-    long value = 19791012;
+    long l1 = 1, l2 = 2, l3 = 3;
 
     Consumer<CodeBuilder> cb =
         xb -> {
-          xb.ldc(value);
+          xb.ldc(l1);
+          xb.invokestatic(ConstantDescs.CD_Long, "valueOf", ConstantDescs.MTD_Longlong);
+          xb.ldc(l2);
           xb.invokestatic(ConstantDescs.CD_Long, "valueOf", ConstantDescs.MTD_Longlong);
           xb.invokedynamic(
               DynamicCallSiteDesc.of(
-                  ConstantDescs.DYNAMIC_STORER_BSM,
-                  globalname,
-                  ConstantDescs.MTD_voidObject,
-                  packagename));
-          xb.aconst_null();
+                  ConstantDescs.BSM_BINARY_DISPATCHER, "+", ConstantDescs.MTD_ObjectObjectObject));
+          xb.checkcast(ConstantDescs.CD_Long);
           xb.areturn();
         };
 
     var bytes =
         ClassFile.of()
             .build(
-                ClassDesc.of(this.getClass().getPackageName() + ".C"),
+                ClassDesc.of(TEST_CLASS),
                 clb -> {
                   clb.withMethodBody("m", mtd, ACC_PUBLIC | ACC_STATIC, cb);
                 });
 
     var lookup = MethodHandles.lookup().defineHiddenClass(bytes, true);
     var m = lookup.findStatic(lookup.lookupClass(), "m", mt);
-    assertNull(m.invoke()); // TODO: Check the actual stored value
+    assertEquals(l3, m.invoke(l1, l2));
   }
 }

--- a/src/test/java/com/keronic/majestik/language/invokers/BinaryDispatcherTest.java
+++ b/src/test/java/com/keronic/majestik/language/invokers/BinaryDispatcherTest.java
@@ -4,7 +4,7 @@ import module java.base;
 
 import static java.lang.classfile.ClassFile.ACC_PUBLIC;
 import static java.lang.classfile.ClassFile.ACC_STATIC;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.keronic.majestik.constant.ConstantDescs;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/keronic/majestik/language/invokers/ConstantBuilderTest.java
+++ b/src/test/java/com/keronic/majestik/language/invokers/ConstantBuilderTest.java
@@ -4,7 +4,8 @@ import module java.base;
 
 import static java.lang.classfile.ClassFile.ACC_PUBLIC;
 import static java.lang.classfile.ClassFile.ACC_STATIC;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.keronic.majestik.constant.ConstantDescs;
 import com.keronic.majestik.runtime.internal.ProcImpl;

--- a/src/test/java/com/keronic/majestik/language/invokers/ConstantBuilderTest.java
+++ b/src/test/java/com/keronic/majestik/language/invokers/ConstantBuilderTest.java
@@ -1,4 +1,4 @@
-package com.keronic.language.invokers;
+package com.keronic.majestik.language.invokers;
 
 import module java.base;
 
@@ -11,6 +11,9 @@ import com.keronic.majestik.runtime.internal.ProcImpl;
 import org.junit.jupiter.api.Test;
 
 public class ConstantBuilderTest {
+  private static final String TEST_PACKAGE = ConstantBuilderTest.class.getPackageName();
+  private static final String TEST_CLASS = TEST_PACKAGE + ".C";
+
   public static Object testM() {
     return Integer.valueOf(12345);
   }
@@ -36,7 +39,7 @@ public class ConstantBuilderTest {
     var bytes =
         ClassFile.of()
             .build(
-                ClassDesc.of(this.getClass().getPackageName() + ".C"),
+                ClassDesc.of(TEST_CLASS),
                 clb -> {
                   clb.withMethodBody("m", mtd, ACC_PUBLIC | ACC_STATIC, cb);
                 });
@@ -76,7 +79,7 @@ public class ConstantBuilderTest {
     var bytes =
         ClassFile.of()
             .build(
-                ClassDesc.of(this.getClass().getPackageName() + ".C"),
+                ClassDesc.of(TEST_CLASS),
                 clb -> {
                   clb.withMethodBody("m", mtd, ACC_PUBLIC | ACC_STATIC, cb);
                 });

--- a/src/test/java/com/keronic/majestik/language/invokers/DynamicAccessorTest.java
+++ b/src/test/java/com/keronic/majestik/language/invokers/DynamicAccessorTest.java
@@ -1,4 +1,4 @@
-package com.keronic.language.invokers;
+package com.keronic.majestik.language.invokers;
 
 import module java.base;
 
@@ -9,39 +9,45 @@ import static org.junit.jupiter.api.Assertions.*;
 import com.keronic.majestik.constant.ConstantDescs;
 import org.junit.jupiter.api.Test;
 
-class BinaryDispatcherTest {
+class DynamicAccessorTest {
+  private static final String TEST_PACKAGE = DynamicAccessorTest.class.getPackageName();
+  private static final String TEST_CLASS = TEST_PACKAGE + ".C";
+
   /**
    * @throws Throwable
    */
   @Test
-  void testLongPlusLong() throws Throwable {
-    var mt = MethodType.methodType(Long.class, Long.class, Long.class);
+  void testStoreDynamic() throws Throwable {
+    var mt = MethodType.methodType(Object.class);
     var mtd = mt.describeConstable().get();
-    long l1 = 1, l2 = 2, l3 = 3;
+    var globalname = "!_test_!";
+    var packagename = "user";
+    long value = 19791012;
 
     Consumer<CodeBuilder> cb =
         xb -> {
-          xb.ldc(l1);
-          xb.invokestatic(ConstantDescs.CD_Long, "valueOf", ConstantDescs.MTD_Longlong);
-          xb.ldc(l2);
+          xb.ldc(value);
           xb.invokestatic(ConstantDescs.CD_Long, "valueOf", ConstantDescs.MTD_Longlong);
           xb.invokedynamic(
               DynamicCallSiteDesc.of(
-                  ConstantDescs.BSM_BINARY_DISPATCHER, "+", ConstantDescs.MTD_ObjectObjectObject));
-          xb.checkcast(ConstantDescs.CD_Long);
+                  ConstantDescs.BSM_DYNAMIC_STORER,
+                  globalname,
+                  ConstantDescs.MTD_voidObject,
+                  packagename));
+          xb.aconst_null();
           xb.areturn();
         };
 
     var bytes =
         ClassFile.of()
             .build(
-                ClassDesc.of(this.getClass().getPackageName() + ".C"),
+                ClassDesc.of(TEST_CLASS),
                 clb -> {
                   clb.withMethodBody("m", mtd, ACC_PUBLIC | ACC_STATIC, cb);
                 });
 
     var lookup = MethodHandles.lookup().defineHiddenClass(bytes, true);
     var m = lookup.findStatic(lookup.lookupClass(), "m", mt);
-    assertEquals(l3, m.invoke(l1, l2));
+    assertNull(m.invoke()); // TODO: Check the actual stored value
   }
 }

--- a/src/test/java/com/keronic/majestik/language/invokers/DynamicAccessorTest.java
+++ b/src/test/java/com/keronic/majestik/language/invokers/DynamicAccessorTest.java
@@ -4,7 +4,7 @@ import module java.base;
 
 import static java.lang.classfile.ClassFile.ACC_PUBLIC;
 import static java.lang.classfile.ClassFile.ACC_STATIC;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.keronic.majestik.constant.ConstantDescs;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/keronic/majestik/language/invokers/GlobalAccessorTest.java
+++ b/src/test/java/com/keronic/majestik/language/invokers/GlobalAccessorTest.java
@@ -10,6 +10,9 @@ import com.keronic.majestik.constant.ConstantDescs;
 import org.junit.jupiter.api.Test;
 
 /** */
+/**
+ * Tests for the GlobalAccessor class which handles global variable storage and retrieval.
+ */
 class GlobalAccessorTest {
   private static final String TEST_PACKAGE = GlobalAccessorTest.class.getPackageName();
   private static final String TEST_CLASS = TEST_PACKAGE + ".C";

--- a/src/test/java/com/keronic/majestik/language/invokers/GlobalAccessorTest.java
+++ b/src/test/java/com/keronic/majestik/language/invokers/GlobalAccessorTest.java
@@ -1,4 +1,4 @@
-package com.keronic.language.invokers;
+package com.keronic.majestik.language.invokers;
 
 import module java.base;
 
@@ -11,6 +11,8 @@ import org.junit.jupiter.api.Test;
 
 /** */
 class GlobalAccessorTest {
+  private static final String TEST_PACKAGE = GlobalAccessorTest.class.getPackageName();
+  private static final String TEST_CLASS = TEST_PACKAGE + ".C";
   /**
    * @throws Throwable
    */
@@ -20,7 +22,7 @@ class GlobalAccessorTest {
     var mtd = mt.describeConstable().get();
 
     Consumer<CodeBuilder> cb =
-	xb -> {
+        xb -> {
           xb.ldc((long) 54321);
           xb.invokestatic(ConstantDescs.CD_Long, "valueOf", ConstantDescs.MTD_Longlong);
           xb.invokedynamic(
@@ -30,20 +32,20 @@ class GlobalAccessorTest {
                   ConstantDescs.MTD_voidObject,
                   "user",
                   "test"));
-	  xb.invokedynamic(
+          xb.invokedynamic(
               DynamicCallSiteDesc.of(
                   ConstantDescs.BSM_GLOBAL_FETCHER,
                   "fetch",
                   ConstantDescs.MTD_Object,
                   "user",
                   "test"));
-	  xb.areturn();
-	};
+          xb.areturn();
+        };
 
     var bytes =
 	ClassFile.of()
 	    .build(
-                ClassDesc.of(this.getClass().getPackageName() + ".C"),
+                ClassDesc.of(TEST_CLASS),
 		clb -> {
 		  clb.withMethodBody("m", mtd, ACC_PUBLIC | ACC_STATIC, cb);
 		});

--- a/src/test/java/com/keronic/majestik/language/invokers/GlobalAccessorTest.java
+++ b/src/test/java/com/keronic/majestik/language/invokers/GlobalAccessorTest.java
@@ -4,7 +4,7 @@ import module java.base;
 
 import static java.lang.classfile.ClassFile.ACC_PUBLIC;
 import static java.lang.classfile.ClassFile.ACC_STATIC;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.keronic.majestik.constant.ConstantDescs;
 import org.junit.jupiter.api.Test;
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 class GlobalAccessorTest {
   private static final String TEST_PACKAGE = GlobalAccessorTest.class.getPackageName();
   private static final String TEST_CLASS = TEST_PACKAGE + ".C";
+
   /**
    * @throws Throwable
    */
@@ -43,12 +44,12 @@ class GlobalAccessorTest {
         };
 
     var bytes =
-	ClassFile.of()
-	    .build(
+        ClassFile.of()
+            .build(
                 ClassDesc.of(TEST_CLASS),
-		clb -> {
-		  clb.withMethodBody("m", mtd, ACC_PUBLIC | ACC_STATIC, cb);
-		});
+                clb -> {
+                  clb.withMethodBody("m", mtd, ACC_PUBLIC | ACC_STATIC, cb);
+                });
 
     var lookup = MethodHandles.lookup().defineHiddenClass(bytes, true);
     var m = lookup.findStatic(lookup.lookupClass(), "m", mt);

--- a/src/test/java/com/keronic/majestik/language/invokers/ProcInvokerTest.java
+++ b/src/test/java/com/keronic/majestik/language/invokers/ProcInvokerTest.java
@@ -4,7 +4,7 @@ import module java.base;
 
 import static java.lang.classfile.ClassFile.ACC_PUBLIC;
 import static java.lang.classfile.ClassFile.ACC_STATIC;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.keronic.majestik.constant.ConstantDescs;
 import com.keronic.majestik.runtime.objects.Package;
@@ -60,11 +60,9 @@ class ProcInvokerTest {
   /**
    * Cleans up resources after each test by removing the dynamically registered class from the
    * package.
-   *
-   * @throws Throwable if an error occurs during teardown.
    */
   @AfterEach
-  void tearDown() throws Throwable {
+  void tearDown() {
     Package.put("sw", "run_test", null);
   }
 

--- a/src/test/java/com/keronic/majestik/language/invokers/ProcInvokerTest.java
+++ b/src/test/java/com/keronic/majestik/language/invokers/ProcInvokerTest.java
@@ -1,4 +1,4 @@
-package com.keronic.language.invokers;
+package com.keronic.majestik.language.invokers;
 
 import module java.base;
 
@@ -14,6 +14,8 @@ import org.junit.jupiter.api.Test;
 
 /** */
 class ProcInvokerTest {
+  private static final String TEST_PACKAGE = ProcInvokerTest.class.getPackageName();
+  private static final String TEST_CLASS = TEST_PACKAGE + ".C";
 
   /**
    * Sets up the test environment before each test case. This method dynamically constructs a class
@@ -23,7 +25,7 @@ class ProcInvokerTest {
    */
   @BeforeEach
   void setUp() throws Throwable {
-    var cdTestClass = ClassDesc.of(this.getClass().getPackageName() + ".T");
+    var cdTestClass = ClassDesc.of(TEST_PACKAGE + ".T");
     var cdProcImpl = ClassDesc.of("com.keronic.majestik.runtime.internal.ProcImpl");
     var tbytes =
         ClassFile.of()
@@ -95,15 +97,15 @@ class ProcInvokerTest {
               DynamicCallSiteDesc.of(
                   ConstantDescs.BSM_NATURAL_PROC, "()", ConstantDescs.MTD_ObjectObjectObject));
           xb.areturn();
-    };
+        };
 
     var bytes =
         ClassFile.of()
             .build(
-                ClassDesc.of(this.getClass().getPackageName() + ".C"),
+                ClassDesc.of(TEST_CLASS),
                 clb -> {
-      clb.withMethodBody("m", mtd, ACC_PUBLIC | ACC_STATIC, cb);
-    });
+                  clb.withMethodBody("m", mtd, ACC_PUBLIC | ACC_STATIC, cb);
+                });
 
     var lookup = MethodHandles.lookup().defineHiddenClass(bytes, true);
     var m = lookup.findStatic(lookup.lookupClass(), "m", mt);

--- a/src/test/java/com/keronic/majestik/language/invokers/TupleBuilderTest.java
+++ b/src/test/java/com/keronic/majestik/language/invokers/TupleBuilderTest.java
@@ -1,4 +1,4 @@
-package com.keronic.language.invokers;
+package com.keronic.majestik.language.invokers;
 
 import module java.base;
 
@@ -12,6 +12,9 @@ import org.junit.jupiter.api.Test;
 
 /** */
 class TupleBuilderTest {
+  private static final String TEST_PACKAGE = TupleBuilderTest.class.getPackageName();
+  private static final String TEST_CLASS = TEST_PACKAGE + ".C";
+
   /**
    * Tests the dynamic creation of a `ResultTuple` using the `BSM_TUPLE_BUILDER` bootstrap method.
    *
@@ -33,23 +36,23 @@ class TupleBuilderTest {
     var magic = "MagicString";
 
     Consumer<CodeBuilder> cb =
-	    xb -> {
-        xb.ldc(new String(magic));
-	      xb.invokedynamic(
-	        DynamicCallSiteDesc.of(
-		        ConstantDescs.BSM_TUPLE_BUILDER,
-		        "tuplebuilder",
-		        ConstantDescs.MTD_ResultTupleObject));
-        xb.areturn();
-	};
+        xb -> {
+          xb.ldc(new String(magic));
+          xb.invokedynamic(
+              DynamicCallSiteDesc.of(
+                  ConstantDescs.BSM_TUPLE_BUILDER,
+                  "tuplebuilder",
+                  ConstantDescs.MTD_ResultTupleObject));
+          xb.areturn();
+        };
 
     var bytes =
-	ClassFile.of()
-	    .build(
-                ClassDesc.of(this.getClass().getPackageName() + ".C"),
-		clb -> {
-		  clb.withMethodBody("m", mtd, ACC_PUBLIC | ACC_STATIC, cb);
-		});
+        ClassFile.of()
+            .build(
+                ClassDesc.of(TEST_CLASS),
+                clb -> {
+                  clb.withMethodBody("m", mtd, ACC_PUBLIC | ACC_STATIC, cb);
+                });
 
     var lookup = MethodHandles.lookup().defineHiddenClass(bytes, true);
     var m = lookup.findStatic(lookup.lookupClass(), "m", mt);

--- a/src/test/java/com/keronic/majestik/language/invokers/TupleBuilderTest.java
+++ b/src/test/java/com/keronic/majestik/language/invokers/TupleBuilderTest.java
@@ -4,7 +4,7 @@ import module java.base;
 
 import static java.lang.classfile.ClassFile.ACC_PUBLIC;
 import static java.lang.classfile.ClassFile.ACC_STATIC;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.keronic.majestik.constant.ConstantDescs;
 import com.keronic.majestik.language.ResultTuple;

--- a/src/test/java/com/keronic/majestik/language/utils/MagikObjectUtilsTest.java
+++ b/src/test/java/com/keronic/majestik/language/utils/MagikObjectUtilsTest.java
@@ -1,15 +1,16 @@
 package com.keronic.majestik.language.utils;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import com.keronic.majestik.MajestikRuntimeException;
 import org.junit.jupiter.api.Test;
 
 class MagikObjectUtilsTest {
-
   @Test
-  void testShouldBeBoolean() throws Throwable {
-    assertSame(true, MagikObjectUtils.should_be_boolean(Boolean.TRUE));
-    assertSame(false, MagikObjectUtils.should_be_boolean(Boolean.FALSE));
+  void testShouldBeBoolean() {
+    assertEquals(true, MagikObjectUtils.should_be_boolean(Boolean.TRUE));
+    assertEquals(false, MagikObjectUtils.should_be_boolean(Boolean.FALSE));
 
     assertThrows(
         MajestikRuntimeException.class,

--- a/src/test/java/com/keronic/majestik/language/utils/MagikObjectUtilsTest.java
+++ b/src/test/java/com/keronic/majestik/language/utils/MagikObjectUtilsTest.java
@@ -1,0 +1,20 @@
+package com.keronic.majestik.language.utils;
+
+import static org.junit.jupiter.api.Assertions.*;
+import com.keronic.majestik.MajestikRuntimeException;
+import org.junit.jupiter.api.Test;
+
+class MagikObjectUtilsTest {
+
+  @Test
+  void testShouldBeBoolean() throws Throwable {
+    assertSame(true, MagikObjectUtils.should_be_boolean(Boolean.TRUE));
+    assertSame(false, MagikObjectUtils.should_be_boolean(Boolean.FALSE));
+
+    assertThrows(
+        MajestikRuntimeException.class,
+        () -> {
+          MagikObjectUtils.should_be_boolean(null);
+        });
+  }
+}

--- a/src/test/magik/ifexpression.magik
+++ b/src/test/magik/ifexpression.magik
@@ -1,0 +1,8 @@
+_block
+	_if _false
+	_then
+		write("skip this")
+	_else
+		write("success")
+	_endif
+_endblock

--- a/src/test/magik/test_cases.json
+++ b/src/test/magik/test_cases.json
@@ -1,9 +1,14 @@
 {
     "test_cases": [
         {
-            "file": "write_string.magik",
-            "description": "Test string output with newline",
-            "expected": "Hello\nWorld!"
+            "file": "write_boolean.magik",
+            "description": "Test boolean output",
+            "expected": "true\nfalse"
+        },
+        {
+            "file": "write_float.magik",
+            "description": "Test float output",
+            "expected": "5.4321"
         },
         {
             "file": "write_integer.magik",
@@ -11,9 +16,14 @@
             "expected": "12345"
         },
         {
-            "file": "write_float.magik",
-            "description": "Test float output",
-            "expected": "5.4321"
+            "file": "write_string.magik",
+            "description": "Test string output with newline",
+            "expected": "Hello\nWorld!"
+        },
+        {
+            "file": "ifexpression.magik",
+            "description": "Test if expression",
+            "expected": "success"
         }
     ]
 }

--- a/src/test/magik/write_boolean.magik
+++ b/src/test/magik/write_boolean.magik
@@ -1,0 +1,4 @@
+_block
+	write(_true)
+	write(_false)
+_endblock


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced boolean values and conditional expressions to enhance language capabilities.
	- New methods for processing boolean expressions and "if" expressions in the code visitor.
	- Added a utility class for boolean checks.
	- New test class for validating boolean utility functions.
	- Added support for new test cases related to boolean outputs and if expressions.
	- Implemented a new block for writing boolean values in the language.
	- Enhanced README documentation to reflect new features and improved structure.

- **Bug Fixes**
	- Improved error handling for number parsing in the code visitor.

- **Tests**
	- Expanded test coverage for lexer functionalities, including new tests for boolean handling and conditional expressions.
	- Added tests for if-then-else structures in the parser.
	- Introduced a new test class for utility functions related to boolean checks.
	- Updated test cases to focus on boolean outputs and conditional expressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->