### PR TITLE
Update JDK from 22 to 23 and improve logging and code formatting

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -25,10 +25,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - name: Set up JDK 22
+    - name: Set up JDK 23
       uses: actions/setup-java@v4
       with:
-        java-version: '22'
+        java-version: '23'
         distribution: 'temurin'
         cache: maven
     - name: Build with Maven

--- a/README.md
+++ b/README.md
@@ -58,15 +58,15 @@ java --enable-preview -jar target/majestik-0.0.0-SNAPSHOT.jar helloworld.magik
 
 FAQ
 ---
-* Q: Why does Majestik require JDK 22?
-  A: Majestik uses the Class-File API[^3], which was introduced as a preview feature in Java 22.
+* Q: Why does Majestik require JDK 23?
+  A: Majestik uses the Class-File API[^3], which was introduced as a preview feature in Java 23.
 
 * Q: Can generated class files be used in a (Smallworld) Magik session?
-  A: Yes, they can be used in a Magik session, provided the Magik session is started with JDK 22 with preview features enabled.
+  A: Yes, they can be used in a Magik session, provided the Magik session is started with JDK 23 with preview features enabled.
 
 
 
 [^1]: [Magik (programming language) on Wikipedia](https://en.wikipedia.org/wiki/Magik_(programming_language))
 [^2]: [ANTLR4](https://www.antlr.org)
-[^3]: [Class-File API](https://docs.oracle.com/en/java/javase/22/docs/api/java.base/java/lang/classfile/package-summary.html)
+[^3]: [Class-File API](https://docs.oracle.com/en/java/javase/23/docs/api/java.base/java/lang/classfile/package-summary.html)
 [^4]: [Magik Hello World example](https://en.wikipedia.org/wiki/Magik_(programming_language)#Hello_World_example)

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ FAQ
   A: Majestik uses the Class-File API[^3], which was introduced as a preview feature in Java 23.
 
 * Q: Can generated class files be used in a (Smallworld) Magik session?
-  A: Yes, they can be used in a Magik session, provided the Magik session is started with JDK 23 with preview features enabled.
+  A: Yes, they can be used in a Magik session, provided the Magik session is started with JDK 23 and preview features are enabled.
 
 
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ java --enable-preview -jar target/majestik-0.0.0-SNAPSHOT.jar helloworld.magik
 
 FAQ
 ---
+
 * Q: Why does Majestik require JDK 23?
   A: Majestik uses the Class-File API[^3], which was introduced as a preview feature in Java 23.
 

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>3.5.0</version>
           <configuration>
-            <argLine>@{argLine} --enable-preview</argLine>
+            <argLine>@{argLine} -Djava.util.logging.config.file=src/test/resources/jul.properties --enable-preview</argLine>
           </configuration>
         </plugin>
         <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -11,8 +11,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>22</maven.compiler.source>
-    <maven.compiler.target>22</maven.compiler.target>
+    <maven.compiler.source>23</maven.compiler.source>
+    <maven.compiler.target>23</maven.compiler.target>
 
     <sonar.organization>krn-robin</sonar.organization>
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>

--- a/src/main/java/com/keronic/Majestik.java
+++ b/src/main/java/com/keronic/Majestik.java
@@ -1,16 +1,13 @@
 /** */
 package com.keronic;
 
+import module java.base;
+
 import com.keronic.antlr4.MajestikBaseVisitor;
 import com.keronic.antlr4.MajestikLexer;
 import com.keronic.antlr4.MajestikParser;
 import com.keronic.antlr4.MajestikParser.ProgContext;
 import com.keronic.majestik.MajestikRuntimeException;
-import java.io.File;
-import java.lang.classfile.ClassFile;
-import java.lang.constant.ClassDesc;
-import java.lang.constant.ConstantDescs;
-import java.nio.file.Path;
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
@@ -25,11 +22,11 @@ public class Majestik {
 		System.out.println("Majestik v0.0");
 
 		try {
+      // FIXME: force load of stub sw:write proc
 			@SuppressWarnings("unused")
       var wp =
           Class.forName(
-              "com.keronic.majestik.runtime.WriteProcTemp"); // FIXME: force load of stub sw:write
-      // proc
+              "com.keronic.majestik.runtime.WriteProcTemp");
 		} catch (Exception e) {
       throw new MajestikRuntimeException(e);
 		}

--- a/src/main/java/com/keronic/Majestik.java
+++ b/src/main/java/com/keronic/Majestik.java
@@ -8,71 +8,83 @@ import com.keronic.antlr4.MajestikLexer;
 import com.keronic.antlr4.MajestikParser;
 import com.keronic.antlr4.MajestikParser.ProgContext;
 import com.keronic.majestik.MajestikRuntimeException;
+import java.lang.System.Logger.Level;
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 
 /** */
 public class Majestik {
+  private static final System.Logger LOGGER =
+      System.getLogger(MethodHandles.lookup().lookupClass().getName());
 
 	/**
 	 * @param args
 	 */
 	public static void main(String[] args) {
-		System.out.println("Majestik v0.0");
+    LOGGER.log(Level.INFO, () -> "Majestik v0.0");
 
 		try {
       // FIXME: force load of stub sw:write proc
 			@SuppressWarnings("unused")
-      var wp =
-          Class.forName(
-              "com.keronic.majestik.runtime.WriteProcTemp");
+      var wp = Class.forName("com.keronic.majestik.runtime.WriteProcTemp");
 		} catch (Exception e) {
       throw new MajestikRuntimeException(e);
 		}
 
-		if (args.length == 0)
-			System.out.println("Usage: majestik file.magik");
+    if (args.length == 0) LOGGER.log(Level.ERROR, () -> "Usage: majestik file.magik");
 		else
 			try {
-				System.out.println(String.format("LOG: Reading file: %s", args[0]));
+        LOGGER.log(Level.INFO, () -> String.format("Reading file: %s", args[0]));
 				CharStream in = CharStreams.fromFileName(args[0]);
 				MajestikLexer lexer = new MajestikLexer(in);
 				MajestikParser parser = new MajestikParser(new CommonTokenStream(lexer));
 				ProgContext tree = parser.prog(); // parse
-				MajestikBaseVisitor<Void> mbv = new MajestikBaseVisitor<Void>(); // Yield unrecognized tokens early
+        MajestikBaseVisitor<Void> mbv =
+            new MajestikBaseVisitor<Void>(); // Yield unrecognized tokens early
 				mbv.visit(tree);
 
-				System.out.println("LOG: Compiling...");
+        LOGGER.log(Level.INFO, () -> String.format("Compiling..."));
 				var baseName = PathUtils.getBaseName(args[0]);
-				var dir = new File("majestik");
-				if (!dir.exists())
-					dir.mkdir(); // TODO: move to pathutils
+        Files.createDirectories(Path.of("majestik"));
 
 				var newFileName = "majestik/%s.class".formatted(baseName); // TODO: move to pathutils
-				System.out.format("Writing to classfile: %s\n", newFileName);
-				ClassFile.of().buildTo(Path.of(newFileName),
+        LOGGER.log(Level.INFO, () -> String.format("Writing to classfile: %s%n", newFileName));
+        ClassFile.of()
+            .buildTo(
+                Path.of(newFileName),
 						ClassDesc.of("majestik.%s".formatted(baseName)),
-						classBuilder -> classBuilder
-								.withMethodBody(ConstantDescs.INIT_NAME, ConstantDescs.MTD_void, ClassFile.ACC_PUBLIC,
-										codeBuilder -> codeBuilder.aload(0)
-												.invokespecial(ConstantDescs.CD_Object, ConstantDescs.INIT_NAME,
+                classBuilder ->
+                    classBuilder
+                        .withMethodBody(
+                            ConstantDescs.INIT_NAME,
+                            ConstantDescs.MTD_void,
+                            ClassFile.ACC_PUBLIC,
+                            codeBuilder ->
+                                codeBuilder
+                                    .aload(0)
+                                    .invokespecial(
+                                        ConstantDescs.CD_Object,
+                                        ConstantDescs.INIT_NAME,
 														ConstantDescs.MTD_void)
 												.return_())
-								.withMethodBody(ConstantDescs.CLASS_INIT_NAME, ConstantDescs.MTD_void,
-										ClassFile.ACC_STATIC, codeBuilder -> {
+                        .withMethodBody(
+                            ConstantDescs.CLASS_INIT_NAME,
+                            ConstantDescs.MTD_void,
+                            ClassFile.ACC_STATIC,
+                            codeBuilder -> {
 											MajestikCodeVisitor mcv = new MajestikCodeVisitor(codeBuilder);
 											mcv.visit(tree);
 											codeBuilder.return_();
 										}));
 				var cl = new MajestikClassLoader();
 
-				System.out.println(String.format("LOG: Loading compiled class: %s",
-						Path.of(newFileName)));
+        LOGGER.log(
+            Level.INFO,
+            () -> String.format("LOG: Loading compiled class: %s", Path.of(newFileName)));
 				cl.loadClass("majestik.%s".formatted(baseName)).getDeclaredConstructor().newInstance();
 			} catch (Exception e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
+        throw new MajestikRuntimeException(e);
 			}
 	}
 }

--- a/src/main/java/com/keronic/MajestikClassLoader.java
+++ b/src/main/java/com/keronic/MajestikClassLoader.java
@@ -24,8 +24,7 @@ public class MajestikClassLoader extends ClassLoader {
 				var cd = this.loadClassData(name);
 				return super.defineClass(name, cd, 0, cd.length);
 			} catch (IOException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
+		    return super.findClass(name);
 			}
 		}
 		return super.findClass(name);

--- a/src/main/java/com/keronic/MajestikClassLoader.java
+++ b/src/main/java/com/keronic/MajestikClassLoader.java
@@ -37,6 +37,7 @@ public class MajestikClassLoader extends ClassLoader {
     var cm = cf.parse(Path.of(fileName));
 		var crm = ClassRemapper.of(REMAP_FUNCTION);
 
+    // Transform the class file, applying the REMAP_FUNCTION to update package names
     return cf.transform(cm, crm);
 	}
 }

--- a/src/main/java/com/keronic/MajestikClassLoader.java
+++ b/src/main/java/com/keronic/MajestikClassLoader.java
@@ -1,32 +1,16 @@
-/**
- *
- */
+/** */
 package com.keronic;
 
-import java.io.File;
-import java.io.IOException;
-import java.lang.classfile.ClassFile;
-import java.lang.classfile.ClassModel;
-import java.lang.classfile.ClassTransform;
-import java.lang.classfile.CodeTransform;
-import java.lang.classfile.components.ClassRemapper;
-import java.lang.classfile.instruction.InvokeDynamicInstruction;
-import java.lang.constant.ClassDesc;
-import java.lang.constant.ConstantDesc;
-import java.lang.constant.DirectMethodHandleDesc;
-import java.lang.constant.DynamicCallSiteDesc;
-import java.lang.constant.MethodHandleDesc;
-import java.lang.constant.MethodTypeDesc;
-import java.nio.file.Path;
-import java.util.function.Function;
+import module java.base;
 
-/**
- *
- */
+/** */
 public class MajestikClassLoader extends ClassLoader {
 
-	static final Function<ClassDesc, ClassDesc> REMAP_FUNCTION = cd -> ClassDesc
-			.of(cd.packageName().replace("com.gesmallworld.magik", "com.keronic.majestik"), cd.displayName());
+  static final Function<ClassDesc, ClassDesc> REMAP_FUNCTION =
+      cd ->
+          ClassDesc.of(
+              cd.packageName().replace("com.gesmallworld.magik", "com.keronic.majestik"),
+              cd.displayName());
 
 	public MajestikClassLoader() {
 		// TODO Auto-generated constructor stub
@@ -35,8 +19,7 @@ public class MajestikClassLoader extends ClassLoader {
 
 	@Override
 	protected Class<?> findClass(String name) throws ClassNotFoundException {
-		if (name.startsWith("magik") ||
-				name.startsWith("majestik")) {
+    if (name.startsWith("magik") || name.startsWith("majestik")) {
 			try {
 				var cd = this.loadClassData(name);
 				return super.defineClass(name, cd, 0, cd.length);
@@ -48,60 +31,13 @@ public class MajestikClassLoader extends ClassLoader {
 		return super.findClass(name);
 	}
 
-	ClassDesc map(ClassDesc cd) {
-		return ClassRemapper.of(REMAP_FUNCTION).map(cd);
-	}
-
-	// Method copied from jdk.internal.classfile.imp.ClassRemapperImpl
-	DirectMethodHandleDesc mapDirectMethodHandle(DirectMethodHandleDesc dmhd) {
-		return switch (dmhd.kind()) {
-			case GETTER, SETTER, STATIC_GETTER, STATIC_SETTER ->
-				MethodHandleDesc.ofField(dmhd.kind(), map(dmhd.owner()),
-						dmhd.methodName(),
-						map(ClassDesc.ofDescriptor(dmhd.lookupDescriptor())));
-			default ->
-				MethodHandleDesc.ofMethod(dmhd.kind(), map(dmhd.owner()),
-						dmhd.methodName(),
-						mapMethodDesc(MethodTypeDesc.ofDescriptor(dmhd.lookupDescriptor())));
-		};
-	}
-
-	// Method copied from jdk.internal.classfile.imp.ClassRemapperImpl
-	MethodTypeDesc mapMethodDesc(MethodTypeDesc desc) {
-		return MethodTypeDesc.of(map(desc.returnType()),
-				desc.parameterList().stream().map(this::map).toArray(ClassDesc[]::new));
-	}
-
 	private byte[] loadClassData(String className) throws IOException {
-		String fileName = className.replace('.', File.separatorChar) + ".class";
+    var fileName = className.replace('.', File.separatorChar) + ".class";
 
-		ClassFile cf = ClassFile.of(ClassFile.ConstantPoolSharingOption.NEW_POOL);
-		ClassModel cm = cf.parse(Path.of(fileName));
-
+    var cf = ClassFile.of(ClassFile.ConstantPoolSharingOption.NEW_POOL);
+    var cm = cf.parse(Path.of(fileName));
 		var crm = ClassRemapper.of(REMAP_FUNCTION);
 
-		CodeTransform bsmrm = (cob, coe) -> {
-			switch (coe) {
-				// JDK-8332505: ClassRemapper should take care of this, but it does not seem to
-				// work for the bootstrapmethods
-				// https://bugs.openjdk.org/browse/JDK-8332505
-				case InvokeDynamicInstruction idi ->
-					cob.invokedynamic(DynamicCallSiteDesc.of(
-							mapDirectMethodHandle(idi.bootstrapMethod()), idi.name().stringValue(),
-							mapMethodDesc(idi.typeSymbol()),
-							idi.bootstrapArgs().stream().toArray(ConstantDesc[]::new)));
-				default ->
-					cob.with(coe);
-			}
-		};
-
-		// TODO: ClassTransform.andThen() does not seem to work to chain the
-		// transformations?
-		byte[] newBytes = cf.transform(cf.parse(cf.transform(cm, crm)), ClassTransform.transformingMethodBodies(bsmrm));
-
-		// FIXME: DEBUG
-		//Files.write(new File("tmp/java_test/bla.class").toPath(), newBytes);
-
-		return newBytes;
+    return cf.transform(cm, crm);
 	}
 }

--- a/src/main/java/com/keronic/MajestikClassLoader.java
+++ b/src/main/java/com/keronic/MajestikClassLoader.java
@@ -33,8 +33,11 @@ public class MajestikClassLoader extends ClassLoader {
 	private byte[] loadClassData(String className) throws IOException {
     var fileName = className.replace('.', File.separatorChar) + ".class";
 
+    // ClassFile instance for parsing and transforming the class file
     var cf = ClassFile.of(ClassFile.ConstantPoolSharingOption.NEW_POOL);
+    // ClassModel representing the parsed class file
     var cm = cf.parse(Path.of(fileName));
+    // ClassRemapper for applying the REMAP_FUNCTION
 		var crm = ClassRemapper.of(REMAP_FUNCTION);
 
     // Transform the class file, applying the REMAP_FUNCTION to update package names

--- a/src/main/java/com/keronic/MajestikCodeVisitor.java
+++ b/src/main/java/com/keronic/MajestikCodeVisitor.java
@@ -1,16 +1,10 @@
 package com.keronic;
 
-import java.lang.classfile.CodeBuilder;
-import java.lang.constant.DynamicCallSiteDesc;
-import java.text.NumberFormat;
-import java.text.ParseException;
-import java.util.Locale;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import module java.base;
 
-import com.keronic.majestik.constant.ConstantDescs;
 import com.keronic.antlr4.MajestikBaseVisitor;
 import com.keronic.antlr4.MajestikParser;
+import com.keronic.majestik.constant.ConstantDescs;
 
 public class MajestikCodeVisitor extends MajestikBaseVisitor<Void> {
 
@@ -55,10 +49,10 @@ public class MajestikCodeVisitor extends MajestikBaseVisitor<Void> {
 		try {
 			var number = NumberFormat.getInstance(Locale.ROOT).parse(numberString);
 			if (number instanceof Long n) {
-				this.cb.constantInstruction(n);
+        this.cb.loadConstant(n);
 				this.cb.invokestatic(ConstantDescs.CD_Long, "valueOf", ConstantDescs.MTD_Longlong);
 			} else if (number instanceof Double n) {
-				this.cb.constantInstruction(n);
+        this.cb.loadConstant(n);
 				this.cb.invokestatic(ConstantDescs.CD_Double, "valueOf", ConstantDescs.MTD_Doubledouble);
 			}
 		} catch (ParseException e) {

--- a/src/main/java/com/keronic/PathUtils.java
+++ b/src/main/java/com/keronic/PathUtils.java
@@ -1,16 +1,10 @@
-/**
- *
- */
+/** */
 package com.keronic;
 
-/**
- *
- */
+/** */
 public class PathUtils {
 
-	/**
-	 *
-	 */
+  /** */
 	public static String getBaseName(String filename) {
 		return filename.replaceAll("(?<=.)\\.[^.]+$", "");
 	}

--- a/src/main/java/com/keronic/majestik/constant/ConstantDescs.java
+++ b/src/main/java/com/keronic/majestik/constant/ConstantDescs.java
@@ -1,8 +1,6 @@
 package com.keronic.majestik.constant;
 
-import java.lang.constant.ClassDesc;
-import java.lang.constant.DirectMethodHandleDesc;
-import java.lang.constant.MethodTypeDesc;
+import module java.base;
 
 public final class ConstantDescs {
 

--- a/src/main/java/com/keronic/majestik/constant/ConstantDescs.java
+++ b/src/main/java/com/keronic/majestik/constant/ConstantDescs.java
@@ -3,6 +3,8 @@ package com.keronic.majestik.constant;
 import module java.base;
 
 public final class ConstantDescs {
+  public static final String INIT_NAME = java.lang.constant.ConstantDescs.INIT_NAME;
+  public static final String CLASS_INIT_NAME = java.lang.constant.ConstantDescs.CLASS_INIT_NAME;
 
 	public static final ClassDesc CD_double = java.lang.constant.ConstantDescs.CD_double;
   public static final ClassDesc CD_int = java.lang.constant.ConstantDescs.CD_int;

--- a/src/main/java/com/keronic/majestik/constant/ConstantDescs.java
+++ b/src/main/java/com/keronic/majestik/constant/ConstantDescs.java
@@ -3,7 +3,9 @@ package com.keronic.majestik.constant;
 import module java.base;
 
 public final class ConstantDescs {
+  // @see java.base/java.lang.constant.ConstantDescs#INIT_NAME
   public static final String INIT_NAME = java.lang.constant.ConstantDescs.INIT_NAME;
+  // @see java.base/java.lang.constant.ConstantDescs#CLASS_INIT_NAME
   public static final String CLASS_INIT_NAME = java.lang.constant.ConstantDescs.CLASS_INIT_NAME;
 
 	public static final ClassDesc CD_double = java.lang.constant.ConstantDescs.CD_double;

--- a/src/main/java/com/keronic/majestik/internal/Utils.java
+++ b/src/main/java/com/keronic/majestik/internal/Utils.java
@@ -1,9 +1,8 @@
 package com.keronic.majestik.internal;
 
+import module java.base;
+
 import com.keronic.majestik.MajestikRuntimeException;
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
 
 public class Utils {
   private Utils() {}

--- a/src/main/java/com/keronic/majestik/language/ResultTuple.java
+++ b/src/main/java/com/keronic/majestik/language/ResultTuple.java
@@ -1,7 +1,7 @@
 /** */
 package com.keronic.majestik.language;
 
-import java.util.Arrays;
+import module java.base;
 
 /** */
 public class ResultTuple {

--- a/src/main/java/com/keronic/majestik/language/invokers/BinaryDispatcher.java
+++ b/src/main/java/com/keronic/majestik/language/invokers/BinaryDispatcher.java
@@ -1,11 +1,8 @@
 package com.keronic.majestik.language.invokers;
 
+import module java.base;
+
 import com.keronic.majestik.internal.Utils;
-import java.lang.invoke.CallSite;
-import java.lang.invoke.ConstantCallSite;
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
 
 /**
  * BinaryDispatcher is responsible for handling binary operations and dispatching them to

--- a/src/main/java/com/keronic/majestik/language/invokers/ConstantBuilder.java
+++ b/src/main/java/com/keronic/majestik/language/invokers/ConstantBuilder.java
@@ -1,11 +1,8 @@
 package com.keronic.majestik.language.invokers;
 
+import module java.base;
+
 import com.keronic.majestik.runtime.Proc;
-import java.lang.invoke.CallSite;
-import java.lang.invoke.ConstantCallSite;
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
 
 public class ConstantBuilder {
   /**

--- a/src/main/java/com/keronic/majestik/language/invokers/DynamicAccessor.java
+++ b/src/main/java/com/keronic/majestik/language/invokers/DynamicAccessor.java
@@ -1,12 +1,9 @@
 /** */
 package com.keronic.majestik.language.invokers;
 
+import module java.base;
+
 import com.keronic.majestik.internal.Utils;
-import java.lang.invoke.CallSite;
-import java.lang.invoke.ConstantCallSite;
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
 
 /** */
 public class DynamicAccessor {

--- a/src/main/java/com/keronic/majestik/language/invokers/GlobalAccessor.java
+++ b/src/main/java/com/keronic/majestik/language/invokers/GlobalAccessor.java
@@ -1,12 +1,9 @@
 /** */
 package com.keronic.majestik.language.invokers;
 
+import module java.base;
+
 import com.keronic.majestik.internal.Utils;
-import java.lang.invoke.CallSite;
-import java.lang.invoke.ConstantCallSite;
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
 
 /** */
 public class GlobalAccessor {

--- a/src/main/java/com/keronic/majestik/language/invokers/Invoker.java
+++ b/src/main/java/com/keronic/majestik/language/invokers/Invoker.java
@@ -2,12 +2,14 @@
 package com.keronic.majestik.language.invokers;
 
 import module java.base;
-
+import com.keronic.majestik.MajestikRuntimeException;
 import com.keronic.majestik.internal.Utils;
 import com.keronic.majestik.runtime.internal.ProcImpl;
 
 /** */
 public class Invoker {
+  private static final System.Logger LOGGER =
+      System.getLogger(MethodHandles.lookup().lookupClass().getName());
   private static MethodHandle todo =
       Utils.findStatic(Invoker.class, "todo", MethodType.genericMethodType(1));
 
@@ -20,11 +22,10 @@ public class Invoker {
 		MutableCallSite proccs = new MutableCallSite(MethodType.methodType(ProcImpl.class));
     ProcImpl proc = (ProcImpl) o;
 		try {
-			System.out.format("INVOKE: %s\n", o);
+      LOGGER.log(System.Logger.Level.DEBUG, () -> String.format("INVOKE: %s%n", o));
 			proc.invoke(o);
 		} catch (Throwable e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
+      throw new MajestikRuntimeException(e);
 		}
 		return null;
     }
@@ -36,7 +37,8 @@ public class Invoker {
    * @return
    */
     public static CallSite tupleBootstrap(MethodHandles.Lookup lookup, String name, MethodType type) {
-		System.out.format("name: %s %s %s\n", lookup, name, type);
+    LOGGER.log(
+        System.Logger.Level.DEBUG, () -> String.format("name: %s %s %s%n", lookup, name, type));
 		return new MutableCallSite(todo);
     }
 

--- a/src/main/java/com/keronic/majestik/language/invokers/Invoker.java
+++ b/src/main/java/com/keronic/majestik/language/invokers/Invoker.java
@@ -1,13 +1,10 @@
 /** */
 package com.keronic.majestik.language.invokers;
 
+import module java.base;
+
 import com.keronic.majestik.internal.Utils;
 import com.keronic.majestik.runtime.internal.ProcImpl;
-import java.lang.invoke.CallSite;
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
-import java.lang.invoke.MutableCallSite;
 
 /** */
 public class Invoker {

--- a/src/main/java/com/keronic/majestik/language/invokers/ProcInvoker.java
+++ b/src/main/java/com/keronic/majestik/language/invokers/ProcInvoker.java
@@ -1,13 +1,10 @@
 /** */
 package com.keronic.majestik.language.invokers;
 
+import module java.base;
+
 import com.keronic.majestik.internal.Utils;
 import com.keronic.majestik.runtime.internal.ProcImpl;
-import java.lang.invoke.CallSite;
-import java.lang.invoke.ConstantCallSite;
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
 
 /**
  * ProcInvoker is responsible for invoking procedures and managing method handles for dynamic

--- a/src/main/java/com/keronic/majestik/language/invokers/TupleBuilder.java
+++ b/src/main/java/com/keronic/majestik/language/invokers/TupleBuilder.java
@@ -1,12 +1,9 @@
 package com.keronic.majestik.language.invokers;
 
+import module java.base;
+
 import com.keronic.majestik.internal.Utils;
 import com.keronic.majestik.language.ResultTuple;
-import java.lang.invoke.CallSite;
-import java.lang.invoke.ConstantCallSite;
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
 
 public class TupleBuilder {
   private static MethodHandle tuplecreator =

--- a/src/main/java/com/keronic/majestik/runtime/internal/ProcImpl.java
+++ b/src/main/java/com/keronic/majestik/runtime/internal/ProcImpl.java
@@ -1,17 +1,15 @@
 /** */
 package com.keronic.majestik.runtime.internal;
 
+import module java.base;
+
 import com.keronic.majestik.internal.Utils;
 import com.keronic.majestik.runtime.Proc;
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
-import java.util.logging.Logger;
 
 /** */
 public class ProcImpl implements Proc {
-  private static final Logger LOGGER =
-      Logger.getLogger(MethodHandles.lookup().lookupClass().getName());
+  private static final System.Logger LOGGER =
+      System.getLogger(MethodHandles.lookup().lookupClass().getName());
 
 	public MethodHandle methodHandle;
 
@@ -33,7 +31,8 @@ public class ProcImpl implements Proc {
       int numArgs,
       int mandatoryArgs,
       boolean iterator) {
-    LOGGER.finest(
+    LOGGER.log(
+        System.Logger.Level.DEBUG,
         () ->
             String.format(
                 "new ProcImpl(%s, %s, %s, %s, %s, %s)",

--- a/src/main/java/com/keronic/majestik/runtime/objects/internal/PackageImpl.java
+++ b/src/main/java/com/keronic/majestik/runtime/objects/internal/PackageImpl.java
@@ -1,16 +1,14 @@
 /** */
 package com.keronic.majestik.runtime.objects.internal;
 
+import module java.base;
+
 import com.keronic.majestik.runtime.objects.Package;
-import java.lang.invoke.MethodHandles;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.logging.Logger;
 
 /** */
 public class PackageImpl implements Package {
-  private static final Logger LOGGER =
-      Logger.getLogger(MethodHandles.lookup().lookupClass().getName());
+  private static final System.Logger LOGGER =
+      System.getLogger(MethodHandles.lookup().lookupClass().getName());
   private static final Map<String, Package> all_packages = new ConcurrentHashMap<>();
   private final Map<String, Object> variables = new ConcurrentHashMap<>();
 	protected final String name;
@@ -41,12 +39,16 @@ public class PackageImpl implements Package {
 	}
 
 	private Object get(String variableName) {
-    LOGGER.finest(() -> String.format("PackageImpl.get(%s, %s)", this.name, variableName));
+    LOGGER.log(
+        System.Logger.Level.DEBUG,
+        () -> String.format("PackageImpl.get(%s, %s)", this.name, variableName));
 		return this.variables.get(variableName);
 	}
 
   private void put(String variableName, Object o) {
-    LOGGER.finest(() -> String.format("PackageImpl.put(%s, %s, %s)", this.name, variableName, o));
+    LOGGER.log(
+        System.Logger.Level.DEBUG,
+        () -> String.format("PackageImpl.put(%s, %s, %s)", this.name, variableName, o));
     if (o != null) this.variables.put(variableName, o);
     else this.variables.remove(variableName);
 	}

--- a/src/test/java/com/keronic/MajestikClassLoaderTest.java
+++ b/src/test/java/com/keronic/MajestikClassLoaderTest.java
@@ -1,8 +1,68 @@
 package com.keronic;
 
+import module java.base;
+
+import static java.lang.constant.ConstantDescs.INIT_NAME;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.keronic.majestik.constant.ConstantDescs;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class MajestikClassLoaderTest {
+  @BeforeEach
+  void setUp() throws Throwable {
+    var dyndesc =
+        DynamicCallSiteDesc.of(
+            java.lang.constant.ConstantDescs.ofCallsiteBootstrap(
+                ClassDesc.of("com.gesmallworld.magik.language.invokers.ConstantBuilder"),
+                "stringBootstrap",
+                ConstantDescs.CD_CallSite,
+                ConstantDescs.CD_String),
+            "string",
+            ConstantDescs.MTD_Object,
+            "test");
+
+    Files.createDirectories(Path.of("magik"));
+
+    ClassFile.of()
+        .buildTo(
+            Path.of("magik/T.class"),
+            ClassDesc.of("magik.T"),
+            clb ->
+                clb.withMethodBody(
+                        INIT_NAME,
+                        ConstantDescs.MTD_void,
+                        ClassFile.ACC_PUBLIC,
+                        cb ->
+                            cb.aload(0)
+                                .invokespecial(
+                                    ConstantDescs.CD_Object, INIT_NAME, ConstantDescs.MTD_void)
+                            .invokedynamic(dyndesc)
+                            .return_()));
+  }
+
+  @AfterEach
+  void tearDown() throws Throwable {
+    Files.deleteIfExists(Path.of("magik/T.class"));
+  }
+
   @Test
-  void testFindClass() {}
+  void testFindClass() throws Throwable {
+    MajestikClassLoader classLoader = new MajestikClassLoader();
+
+    // Test with a valid class name
+    Class<?> validClass = classLoader.findClass("magik.T");
+    assertNotNull(validClass);
+    assertEquals("magik.T", validClass.getName());
+    validClass.getConstructor().newInstance();
+
+    // Test with an invalid class name
+    assertThrows(
+        ClassNotFoundException.class,
+        () -> {
+          classLoader.findClass("magik.Q");
+        });
+  }
 }

--- a/src/test/java/com/keronic/MajestikClassLoaderTest.java
+++ b/src/test/java/com/keronic/MajestikClassLoaderTest.java
@@ -10,6 +10,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class MajestikClassLoaderTest {
+  private static final Path MAGIK_DIR = Path.of("magik");
+  private static final Path T_CLASS_PATH = MAGIK_DIR.resolve("T.class");
+
   @BeforeEach
   void setUp() throws Throwable {
     var dyndesc =
@@ -23,11 +26,11 @@ class MajestikClassLoaderTest {
             ConstantDescs.MTD_Object,
             "test");
 
-    Files.createDirectories(Path.of("magik"));
+    Files.createDirectories(MAGIK_DIR);
 
     ClassFile.of()
         .buildTo(
-            Path.of("magik/T.class"),
+            T_CLASS_PATH,
             ClassDesc.of("magik.T"),
             clb ->
                 clb.withMethodBody(
@@ -46,7 +49,7 @@ class MajestikClassLoaderTest {
 
   @AfterEach
   void tearDown() throws Throwable {
-    Files.deleteIfExists(Path.of("magik/T.class"));
+    Files.deleteIfExists(T_CLASS_PATH);
   }
 
   @Test

--- a/src/test/java/com/keronic/MajestikClassLoaderTest.java
+++ b/src/test/java/com/keronic/MajestikClassLoaderTest.java
@@ -2,7 +2,6 @@ package com.keronic;
 
 import module java.base;
 
-import static java.lang.constant.ConstantDescs.INIT_NAME;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.keronic.majestik.constant.ConstantDescs;
@@ -32,13 +31,15 @@ class MajestikClassLoaderTest {
             ClassDesc.of("magik.T"),
             clb ->
                 clb.withMethodBody(
-                        INIT_NAME,
+                    ConstantDescs.INIT_NAME,
                         ConstantDescs.MTD_void,
                         ClassFile.ACC_PUBLIC,
                         cb ->
                             cb.aload(0)
                                 .invokespecial(
-                                    ConstantDescs.CD_Object, INIT_NAME, ConstantDescs.MTD_void)
+                                ConstantDescs.CD_Object,
+                                ConstantDescs.INIT_NAME,
+                                ConstantDescs.MTD_void)
                             .invokedynamic(dyndesc)
                             .return_()));
   }

--- a/src/test/java/com/keronic/MajestikClassLoaderTest.java
+++ b/src/test/java/com/keronic/MajestikClassLoaderTest.java
@@ -58,11 +58,16 @@ class MajestikClassLoaderTest {
     assertEquals("magik.T", validClass.getName());
     validClass.getConstructor().newInstance();
 
-    // Test with an invalid class name
+    // Test with invalid class names
     assertThrows(
         ClassNotFoundException.class,
         () -> {
-          classLoader.findClass("magik.Q");
+          classLoader.findClass("magik.Q.NonExistingClass");
+        });
+    assertThrows(
+	    ClassNotFoundException.class,
+	    () -> {
+	      classLoader.findClass("com.example.NonExistingClass");
         });
   }
 }

--- a/src/test/java/com/keronic/MajestikCodeVisitorTest.java
+++ b/src/test/java/com/keronic/MajestikCodeVisitorTest.java
@@ -1,5 +1,7 @@
 package com.keronic;
 
+import module java.base;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -7,8 +9,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.keronic.antlr4.MajestikParser;
-import java.lang.classfile.CodeBuilder;
-import java.lang.classfile.constantpool.InvokeDynamicEntry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/keronic/language/invokers/BinaryDispatcherTest.java
+++ b/src/test/java/com/keronic/language/invokers/BinaryDispatcherTest.java
@@ -1,17 +1,12 @@
 package com.keronic.language.invokers;
 
+import module java.base;
+
 import static java.lang.classfile.ClassFile.ACC_PUBLIC;
 import static java.lang.classfile.ClassFile.ACC_STATIC;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.keronic.majestik.constant.ConstantDescs;
-import java.lang.classfile.ClassFile;
-import java.lang.classfile.CodeBuilder;
-import java.lang.constant.ClassDesc;
-import java.lang.constant.DynamicCallSiteDesc;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
-import java.util.function.Consumer;
 import org.junit.jupiter.api.Test;
 
 class BinaryDispatcherTest {

--- a/src/test/java/com/keronic/language/invokers/ConstantBuilderTest.java
+++ b/src/test/java/com/keronic/language/invokers/ConstantBuilderTest.java
@@ -1,18 +1,13 @@
 package com.keronic.language.invokers;
 
+import module java.base;
+
 import static java.lang.classfile.ClassFile.ACC_PUBLIC;
 import static java.lang.classfile.ClassFile.ACC_STATIC;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.keronic.majestik.constant.ConstantDescs;
 import com.keronic.majestik.runtime.internal.ProcImpl;
-import java.lang.classfile.ClassFile;
-import java.lang.classfile.CodeBuilder;
-import java.lang.constant.ClassDesc;
-import java.lang.constant.DynamicCallSiteDesc;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
-import java.util.function.Consumer;
 import org.junit.jupiter.api.Test;
 
 public class ConstantBuilderTest {

--- a/src/test/java/com/keronic/language/invokers/DynamicAccessorTest.java
+++ b/src/test/java/com/keronic/language/invokers/DynamicAccessorTest.java
@@ -1,17 +1,12 @@
 package com.keronic.language.invokers;
 
+import module java.base;
+
 import static java.lang.classfile.ClassFile.ACC_PUBLIC;
 import static java.lang.classfile.ClassFile.ACC_STATIC;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.keronic.majestik.constant.ConstantDescs;
-import java.lang.classfile.ClassFile;
-import java.lang.classfile.CodeBuilder;
-import java.lang.constant.ClassDesc;
-import java.lang.constant.DynamicCallSiteDesc;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
-import java.util.function.Consumer;
 import org.junit.jupiter.api.Test;
 
 class DynamicAccessorTest {

--- a/src/test/java/com/keronic/language/invokers/GlobalAccessorTest.java
+++ b/src/test/java/com/keronic/language/invokers/GlobalAccessorTest.java
@@ -1,17 +1,12 @@
 package com.keronic.language.invokers;
 
+import module java.base;
+
 import static java.lang.classfile.ClassFile.ACC_PUBLIC;
 import static java.lang.classfile.ClassFile.ACC_STATIC;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.keronic.majestik.constant.ConstantDescs;
-import java.lang.classfile.ClassFile;
-import java.lang.classfile.CodeBuilder;
-import java.lang.constant.ClassDesc;
-import java.lang.constant.DynamicCallSiteDesc;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
-import java.util.function.Consumer;
 import org.junit.jupiter.api.Test;
 
 /** */

--- a/src/test/java/com/keronic/language/invokers/ProcInvokerTest.java
+++ b/src/test/java/com/keronic/language/invokers/ProcInvokerTest.java
@@ -1,19 +1,13 @@
 package com.keronic.language.invokers;
 
+import module java.base;
+
 import static java.lang.classfile.ClassFile.ACC_PUBLIC;
 import static java.lang.classfile.ClassFile.ACC_STATIC;
-import static java.lang.constant.ConstantDescs.INIT_NAME;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.keronic.majestik.constant.ConstantDescs;
 import com.keronic.majestik.runtime.objects.Package;
-import java.lang.classfile.ClassFile;
-import java.lang.classfile.CodeBuilder;
-import java.lang.constant.ClassDesc;
-import java.lang.constant.DynamicCallSiteDesc;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
-import java.util.function.Consumer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -43,7 +37,7 @@ class ProcInvokerTest {
                             ACC_PUBLIC | ACC_STATIC,
                             cb -> cb.aload(1).areturn())
                         .withMethodBody(
-                            INIT_NAME,
+                            ConstantDescs.INIT_NAME,
                             ConstantDescs.MTD_void,
                             ClassFile.ACC_PUBLIC,
                             cb ->
@@ -53,7 +47,9 @@ class ProcInvokerTest {
                                     .loadConstant("run_test")
                                     .loadConstant(2)
                                     .invokespecial(
-                                        cd_p, INIT_NAME, ConstantDescs.MTD_voidClassStringStringint)
+                                        cd_p,
+                                        ConstantDescs.INIT_NAME,
+                                        ConstantDescs.MTD_voidClassStringStringint)
                                     .return_()));
     var tlookup = MethodHandles.lookup().defineHiddenClass(tbytes, true);
     Package.put("sw", "run_test", tlookup.lookupClass().getDeclaredConstructor().newInstance());

--- a/src/test/java/com/keronic/language/invokers/ProcInvokerTest.java
+++ b/src/test/java/com/keronic/language/invokers/ProcInvokerTest.java
@@ -23,14 +23,14 @@ class ProcInvokerTest {
    */
   @BeforeEach
   void setUp() throws Throwable {
-    var cd_t = ClassDesc.of(this.getClass().getPackageName() + ".T");
-    var cd_p = ClassDesc.of("com.keronic.majestik.runtime.internal.ProcImpl");
+    var cdTestClass = ClassDesc.of(this.getClass().getPackageName() + ".T");
+    var cdProcImpl = ClassDesc.of("com.keronic.majestik.runtime.internal.ProcImpl");
     var tbytes =
         ClassFile.of()
             .build(
-                cd_t,
+                cdTestClass,
                 clb ->
-                    clb.withSuperclass(cd_p)
+                    clb.withSuperclass(cdProcImpl)
                         .withMethodBody(
                             "run",
                             MethodType.genericMethodType(2).describeConstable().get(),
@@ -42,12 +42,12 @@ class ProcInvokerTest {
                             ClassFile.ACC_PUBLIC,
                             cb ->
                                 cb.aload(0)
-                                    .loadConstant(cd_t)
+                                    .loadConstant(cdTestClass)
                                     .loadConstant("run")
                                     .loadConstant("run_test")
                                     .loadConstant(2)
                                     .invokespecial(
-                                        cd_p,
+                                        cdProcImpl,
                                         ConstantDescs.INIT_NAME,
                                         ConstantDescs.MTD_voidClassStringStringint)
                                     .return_()));

--- a/src/test/java/com/keronic/language/invokers/ProcInvokerTest.java
+++ b/src/test/java/com/keronic/language/invokers/ProcInvokerTest.java
@@ -48,10 +48,10 @@ class ProcInvokerTest {
                             ClassFile.ACC_PUBLIC,
                             cb ->
                                 cb.aload(0)
-                                    .constantInstruction(cd_t)
-                                    .constantInstruction("run")
-                                    .constantInstruction("run_test")
-                                    .constantInstruction(2)
+                                    .loadConstant(cd_t)
+                                    .loadConstant("run")
+                                    .loadConstant("run_test")
+                                    .loadConstant(2)
                                     .invokespecial(
                                         cd_p, INIT_NAME, ConstantDescs.MTD_voidClassStringStringint)
                                     .return_()));

--- a/src/test/java/com/keronic/language/invokers/TupleBuilderTest.java
+++ b/src/test/java/com/keronic/language/invokers/TupleBuilderTest.java
@@ -1,18 +1,13 @@
 package com.keronic.language.invokers;
 
+import module java.base;
+
 import static java.lang.classfile.ClassFile.ACC_PUBLIC;
 import static java.lang.classfile.ClassFile.ACC_STATIC;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.keronic.majestik.constant.ConstantDescs;
 import com.keronic.majestik.language.ResultTuple;
-import java.lang.classfile.ClassFile;
-import java.lang.classfile.CodeBuilder;
-import java.lang.constant.ClassDesc;
-import java.lang.constant.DynamicCallSiteDesc;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
-import java.util.function.Consumer;
 import org.junit.jupiter.api.Test;
 
 /** */

--- a/src/test/resources/jul.properties
+++ b/src/test/resources/jul.properties
@@ -1,0 +1,3 @@
+handlers=java.util.logging.ConsoleHandler
+java.util.logging.ConsoleHandler.level=ALL
+com.keronic.level=ALL


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Upgraded the Java Development Kit (JDK) version from 22 to 23, enhancing compatibility and performance.
  - Introduced new constants `INIT_NAME` and `CLASS_INIT_NAME` for improved functionality.
  - Added a new logging configuration to enhance logging capabilities throughout the application.

- **Chores**
  - Streamlined imports by removing unused statements and aligning code structure for better maintainability.

- **Tests**
  - Enhanced test coverage for the `MajestikClassLoader` with setup and teardown methods, ensuring robust validation of class loading functionality.
  - Updated various test files to reduce dependencies and improve modularity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->