### PR TITLE
Add support for additive expressions in Majestik language compiler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
           <configuration>
             <java>
               <googleJavaFormat>
-                <version>1.25.0</version>
+                <version>1.25.2</version>
                 <style>GOOGLE</style>
               </googleJavaFormat>
             </java>

--- a/src/main/java/com/keronic/majestik/ast/AdditiveExpressionNode.java
+++ b/src/main/java/com/keronic/majestik/ast/AdditiveExpressionNode.java
@@ -1,0 +1,20 @@
+package com.keronic.majestik.ast;
+
+import module java.base;
+
+import com.keronic.majestik.constant.ConstantDescs;
+
+public class AdditiveExpressionNode extends BinaryOperatorNode {
+  public AdditiveExpressionNode(Node lhs, Node rhs) {
+    super(lhs, rhs);
+  }
+
+  @Override
+  protected void doCompileInto(final CodeBuilder cb) {
+    lhs.compileInto(cb);
+    rhs.compileInto(cb);
+    cb.invokedynamic(
+        DynamicCallSiteDesc.of(
+            ConstantDescs.BSM_BINARY_DISPATCHER, "+", ConstantDescs.MTD_ObjectObjectObject));
+  }
+}

--- a/src/main/java/com/keronic/majestik/ast/AssignmentNode.java
+++ b/src/main/java/com/keronic/majestik/ast/AssignmentNode.java
@@ -12,36 +12,10 @@ import module java.base;
  *     var x = 42;  // AssignmentNode(VariableNode("x"), NumberNode(42))
  *     </pre>
  */
-public class AssignmentNode extends Node {
-  /** The left-hand side (target) of the assignment */
-  private final CompoundNode lhs;
+public class AssignmentNode extends BinaryOperatorNode {
 
-  /** The right-hand side (value) of the assignment */
-  private final CompoundNode rhs;
-
-  public AssignmentNode(CompoundNode lhs, CompoundNode rhs) {
-    this.lhs = Objects.requireNonNull(lhs);
-    this.rhs = Objects.requireNonNull(rhs);
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    return switch (obj) {
-      case null -> false;
-      case AssignmentNode other ->
-          Objects.equals(this.lhs, other.lhs) && Objects.equals(this.rhs, other.rhs);
-      default -> false;
-    };
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(this.lhs, this.rhs);
-  }
-
-  @Override
-  public String toString() {
-    return String.format("AssignmentNode{lhs=%s,rhs=%s}", this.lhs, this.rhs);
+  public AssignmentNode(VariableNode lhs, Node rhs) {
+    super(lhs, rhs);
   }
 
   /**
@@ -53,9 +27,7 @@ public class AssignmentNode extends Node {
   @Override
   protected void doCompileInto(CodeBuilder cb) {
     this.rhs.compileInto(cb);
-    this.lhs.stream()
-        .filter(VariableNode.class::isInstance)
-        .map(VariableNode.class::cast)
-        .forEach(v -> v.compileIntoSet(cb));
+    var vnode = (VariableNode) this.lhs;
+    vnode.compileIntoSet(cb);
   }
 }

--- a/src/main/java/com/keronic/majestik/ast/BinaryOperatorNode.java
+++ b/src/main/java/com/keronic/majestik/ast/BinaryOperatorNode.java
@@ -1,0 +1,38 @@
+package com.keronic.majestik.ast;
+
+import module java.base;
+
+abstract class BinaryOperatorNode extends Node {
+  /** The left-hand side (target) of the operator */
+  final Node lhs;
+
+  /** The right-hand side (value) of the operator */
+  final Node rhs;
+
+  final String CLASSNAME = this.getClass().getSimpleName();
+
+  BinaryOperatorNode(Node lhs, Node rhs) {
+    this.lhs = Objects.requireNonNull(lhs);
+    this.rhs = Objects.requireNonNull(rhs);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    return switch (obj) {
+      case null -> false;
+      case BinaryOperatorNode other ->
+          Objects.equals(this.lhs, other.lhs) && Objects.equals(this.rhs, other.rhs);
+      default -> false;
+    };
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(this.lhs, this.rhs);
+  }
+
+  @Override
+  public String toString() {
+    return String.format("%s{lhs=%s,rhs=%s}", CLASSNAME, this.lhs, this.rhs);
+  }
+}

--- a/src/main/java/com/keronic/majestik/ast/MajestikAbstractVisitor.java
+++ b/src/main/java/com/keronic/majestik/ast/MajestikAbstractVisitor.java
@@ -33,6 +33,7 @@ public abstract class MajestikAbstractVisitor<T> {
     final var nodeType = Objects.requireNonNull(node).getType();
     if (nodeType instanceof MagikGrammar type) {
       return switch (type) {
+        case ADDITIVE_EXPRESSION -> visitAdditiveExpression(node);
         case ASSIGNMENT_EXPRESSION -> visitAssignmentExpression(node);
         case FALSE -> visitFalse(node);
         case IDENTIFIER -> visitIdentifier(node);
@@ -82,6 +83,10 @@ public abstract class MajestikAbstractVisitor<T> {
    * @return result of the visit operation
    */
   protected T visitAssignmentExpression(final AstNode node) {
+    return this.visitDefault(node);
+  }
+
+  protected T visitAdditiveExpression(final AstNode node) {
     return this.visitDefault(node);
   }
 

--- a/src/main/java/com/keronic/majestik/ast/MajestikCodeVisitor.java
+++ b/src/main/java/com/keronic/majestik/ast/MajestikCodeVisitor.java
@@ -17,13 +17,20 @@ public class MajestikCodeVisitor extends MajestikAbstractVisitor<Node> {
   public MajestikCodeVisitor() {}
 
   @Override
+  protected Node visitAdditiveExpression(final AstNode node) {
+    var lhs = this.visit(node.getChildren().getFirst());
+    var rhs = this.visit(node.getChildren().getLast());
+    return new AdditiveExpressionNode(lhs, rhs);
+  }
+
+  @Override
   protected Node visitAssignmentExpression(final AstNode node) {
     var varname = node.getChildren().getFirst().getTokenValue();
     if (!this.varMap.containsKey(varname)) this.varMap.put(varname, this.varMap.size());
     var varidx = this.varMap.get(varname);
 
-    var lhs = new CompoundNode(new VariableNode(varidx));
-    var rhs = new CompoundNode(this.visit(node.getChildren().getLast()));
+    var lhs = new VariableNode(varidx);
+    var rhs = this.visit(node.getChildren().getLast());
 
     return new AssignmentNode(lhs, rhs);
   }

--- a/src/main/java/com/keronic/majestik/language/utils/ExecutableMagik.java
+++ b/src/main/java/com/keronic/majestik/language/utils/ExecutableMagik.java
@@ -3,7 +3,7 @@ package com.keronic.majestik.language.utils;
 
 /** */
 public interface ExecutableMagik {
-	public Object execute();
+	Object execute();
 
-  public default void preload() {}
+  default void preload() {}
 }

--- a/src/test/java/com/keronic/PathUtilsTest.java
+++ b/src/test/java/com/keronic/PathUtilsTest.java
@@ -7,8 +7,8 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for the PathUtils class, focusing on path manipulation and file extension handling
- * functionality (e.g., extracting base names from files with single/double extensions,
- * handling special cases like empty strings and spaces).
+ * functionality (e.g., extracting base names from files with single/double extensions, handling
+ * special cases like empty strings and spaces).
  */
 class PathUtilsTest {
   @Test

--- a/src/test/java/com/keronic/majestik/ast/AdditiveExpressionNodeTest.java
+++ b/src/test/java/com/keronic/majestik/ast/AdditiveExpressionNodeTest.java
@@ -1,0 +1,69 @@
+package com.keronic.majestik.ast;
+
+import module java.base;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import org.junit.jupiter.api.Test;
+
+class AdditiveExpressionNodeTest extends NodeTest {
+  @Test
+  void testEquals() {
+    final var node1 = new AdditiveExpressionNode(new VariableNode(0), new VariableNode(1));
+    final var node2 = new AdditiveExpressionNode(new VariableNode(0), new VariableNode(1));
+    final var node3 = new AdditiveExpressionNode(new VariableNode(0), new VariableNode(2));
+
+    assertEquals(node1, node2);
+
+    assertNotEquals(node1, node3);
+    assertNotEqualsNull(node2);
+  }
+
+  @Test
+  void testHashCode() {
+    final var node1 = new AdditiveExpressionNode(new VariableNode(0), new CompoundNode());
+    final var node2 = new AdditiveExpressionNode(new VariableNode(0), new CompoundNode());
+
+    assertEquals(node1.hashCode(), node2.hashCode());
+  }
+
+  @Test
+  void testToString() {
+    final var node = new AdditiveExpressionNode(new VariableNode(1), new NoOperationNode());
+    assertEquals(
+        "AdditiveExpressionNode{lhs=VariableNode{idx=1},rhs=NoOperationNode{}}", node.toString());
+  }
+
+  @Test
+  void shouldGenerateInvokeDynamicInstruction() {
+    final var cnode = new AdditiveExpressionNode(new NumberNode(1l), new NumberNode(2l));
+
+    final var code = this.compileInto(cnode::compileInto);
+    assertEquals(5, code.elementList().size());
+    final var cel = code.elementList().toArray(new CodeElement[0]);
+
+    final var consins0 = (ConstantInstruction) cel[0];
+    assertEquals(TypeKind.LongType, consins0.typeKind());
+    final var consins1 = (ConstantInstruction) cel[2];
+    assertEquals(TypeKind.LongType, consins1.typeKind());
+
+    final var invins0 = (InvokeInstruction) cel[1];
+    assertEquals("valueOf", invins0.name().toString());
+    assertEquals("(J)Ljava/lang/Long;", invins0.type().toString());
+
+    final var invins1 = (InvokeInstruction) cel[3];
+    assertEquals("valueOf", invins1.name().toString());
+    assertEquals("(J)Ljava/lang/Long;", invins1.type().toString());
+
+    assertInstanceOf(InvokeDynamicInstruction.class, cel[4]);
+    final var indy = (InvokeDynamicInstruction) cel[4];
+
+    // Verify instruction properties
+    assertEquals(
+        "MethodHandleDesc[STATIC/BinaryDispatcher::bootstrap(MethodHandles$Lookup,String,MethodType)CallSite]",
+        indy.bootstrapMethod().toString());
+    assertEquals("+", indy.name().toString());
+  }
+}

--- a/src/test/java/com/keronic/majestik/ast/AssignmentNodeTest.java
+++ b/src/test/java/com/keronic/majestik/ast/AssignmentNodeTest.java
@@ -8,8 +8,8 @@ import org.junit.jupiter.api.Test;
 class AssignmentNodeTest extends NodeTest {
   @Test
   void testEquals() {
-    var node1 = new AssignmentNode(new CompoundNode(), new CompoundNode());
-    var node2 = new AssignmentNode(new CompoundNode(), new CompoundNode());
+    var node1 = new AssignmentNode(new VariableNode(0), new CompoundNode());
+    var node2 = new AssignmentNode(new VariableNode(0), new CompoundNode());
 
     assertEquals(node1, node2);
 
@@ -19,9 +19,15 @@ class AssignmentNodeTest extends NodeTest {
 
   @Test
   void testHashCode() {
-    var node1 = new AssignmentNode(new CompoundNode(), new CompoundNode());
-    var node2 = new AssignmentNode(new CompoundNode(), new CompoundNode());
+    var node1 = new AssignmentNode(new VariableNode(0), new CompoundNode());
+    var node2 = new AssignmentNode(new VariableNode(0), new CompoundNode());
 
     assertEquals(node1.hashCode(), node2.hashCode());
+  }
+
+  @Test
+  void testToString() {
+    var node = new AssignmentNode(new VariableNode(0), new NoOperationNode());
+    assertEquals("AssignmentNode{lhs=VariableNode{idx=0},rhs=NoOperationNode{}}", node.toString());
   }
 }

--- a/src/test/java/com/keronic/majestik/ast/MajestikCodeVisitorTest.java
+++ b/src/test/java/com/keronic/majestik/ast/MajestikCodeVisitorTest.java
@@ -35,6 +35,24 @@ class MajestikCodeVisitorTest {
   }
 
   @Test
+  void testVisitAdditiveExpression() {
+    // Test input
+    var mcv = new MajestikCodeVisitor();
+    var mf = new MagikFile(MagikFile.DEFAULT_URI, ("1 + 1%n").formatted());
+
+    // Execute
+    var node = mcv.scanFile(mf);
+
+    // Verify
+    assertNotNull(node, "Result should not be null");
+    assertInstanceOf(CompoundNode.class, node, "Expected CompoundNode");
+    var cnode = (CompoundNode) node;
+    assertEquals(1, cnode.getChildCount(), "Expected one addtive node");
+    var child0 = cnode.getChild(0);
+    assertInstanceOf(AdditiveExpressionNode.class, child0, "First child should be AdditiveExpressionNode");
+  }
+
+  @Test
   void testVisitAssignmentExpression() {
     // Test input
     var mcv = new MajestikCodeVisitor();

--- a/src/test/java/com/keronic/majestik/ast/NumberNodeTest.java
+++ b/src/test/java/com/keronic/majestik/ast/NumberNodeTest.java
@@ -39,35 +39,28 @@ class NumberNodeTest extends NodeTest {
   @Test
   void shouldGenerateCorrectBytecodeForNumericLiterals() {
     final int EXPECTED_INSTRUCTION_COUNT = 4;
-    final int LONG_CONSTANT_INDEX = 0;
-    final int LONG_INVOKE_INDEX = 1;
-    final int DOUBLE_CONSTANT_INDEX = 2;
-    final int DOUBLE_INVOKE_INDEX = 3;
 
     var compoundNode = new CompoundNode(new NumberNode(1L), new NumberNode(2d));
     var code = this.compileInto(compoundNode::compileInto);
 
     assertEquals(EXPECTED_INSTRUCTION_COUNT, code.elementList().size());
-    var instruction0 = code.elementList().get(LONG_CONSTANT_INDEX);
-    var instruction1 = code.elementList().get(LONG_INVOKE_INDEX);
-    var instruction2 = code.elementList().get(DOUBLE_CONSTANT_INDEX);
-    var instruction3 = code.elementList().get(DOUBLE_INVOKE_INDEX);
+    var cel = code.elementList().toArray(new CodeElement[0]);
 
-    assertInstanceOf(ConstantInstruction.class, instruction0);
-    assertInstanceOf(InvokeInstruction.class, instruction1);
-    assertInstanceOf(ConstantInstruction.class, instruction2);
-    assertInstanceOf(InvokeInstruction.class, instruction3);
+    assertInstanceOf(ConstantInstruction.class, cel[0]);
+    assertInstanceOf(InvokeInstruction.class, cel[1]);
+    assertInstanceOf(ConstantInstruction.class, cel[2]);
+    assertInstanceOf(InvokeInstruction.class, cel[3]);
 
-    var consins0 = (ConstantInstruction) instruction0;
+    var consins0 = (ConstantInstruction) cel[0];
     assertEquals(TypeKind.LongType, consins0.typeKind());
-    var consins1 = (ConstantInstruction) instruction2;
+    var consins1 = (ConstantInstruction) cel[2];
     assertEquals(TypeKind.DoubleType, consins1.typeKind());
 
-    var invins0 = (InvokeInstruction) instruction1;
+    var invins0 = (InvokeInstruction) cel[1];
     assertEquals("valueOf", invins0.name().toString());
     assertEquals("(J)Ljava/lang/Long;", invins0.type().toString());
 
-    var invins1 = (InvokeInstruction) instruction3;
+    var invins1 = (InvokeInstruction) cel[3];
     assertEquals("valueOf", invins1.name().toString());
     assertEquals("(D)Ljava/lang/Double;", invins1.type().toString());
   }

--- a/src/test/magik/addition.magik
+++ b/src/test/magik/addition.magik
@@ -1,0 +1,3 @@
+_block
+	write(54321+12345)
+_endblock

--- a/src/test/magik/test_cases.json
+++ b/src/test/magik/test_cases.json
@@ -21,6 +21,11 @@
             "expected": "Hello\nWorld!"
         },
         {
+	    "file": "addition.magik",
+	    "description": "Test addition",
+	    "expected": "66666"
+	},
+        {
             "file": "ifexpression.magik",
             "description": "Test if expression",
             "expected": "success"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced `AdditiveExpressionNode` class for representing additive expressions.
	- Added a new method for handling additive expressions in the visitor classes.
	- New test cases for `AdditiveExpressionNode` and `AssignmentNode` to enhance test coverage.
	- New block in `addition.magik` for addition operation.
	- New test case in `test_cases.json` for addition functionality.

- **Bug Fixes**
	- Updated method signatures in the `ExecutableMagik` interface for clarity.

- **Documentation**
	- Improved comments in `PathUtilsTest` for better readability.

- **Refactor**
	- Simplified the handling of bytecode instructions in `NumberNodeTest`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->