### PR TITLE
Add support for "_is" identity comparison operator in Majestik language

### DIFF
--- a/src/main/java/com/keronic/majestik/ast/IdentityExpressionNode.java
+++ b/src/main/java/com/keronic/majestik/ast/IdentityExpressionNode.java
@@ -1,0 +1,23 @@
+package com.keronic.majestik.ast;
+
+import module java.base;
+
+import com.keronic.majestik.constant.ConstantDescs;
+
+class IdentityExpressionNode extends BinaryOperatorNode {
+  IdentityExpressionNode(final Node lhs, final Node rhs) {
+    super(lhs, rhs);
+  }
+
+  @Override
+  public void doCompileInto(CodeBuilder cb) {
+    lhs.compileInto(cb);
+    rhs.compileInto(cb);
+    cb.invokestatic(ConstantDescs.CD_MagikObjectUtils, "is", ConstantDescs.MTD_booleanObjectObject);
+    cb.new_(ConstantDescs.CD_Boolean);
+    cb.dup_x1();
+    cb.swap();
+    cb.invokespecial(
+        ConstantDescs.CD_Boolean, ConstantDescs.INIT_NAME, ConstantDescs.MTD_voidboolean);
+  }
+}

--- a/src/main/java/com/keronic/majestik/ast/IfExpressionNode.java
+++ b/src/main/java/com/keronic/majestik/ast/IfExpressionNode.java
@@ -10,10 +10,12 @@ public class IfExpressionNode extends Node {
   private final Node body;
   private final Node elseBody;
 
+  static final Node EMPTYCOMPOUNDNODE = new CompoundNode();
+
   public IfExpressionNode(Node condition, Node body, Node elseBody) {
     this.condition = Objects.requireNonNull(condition);
-    this.body = body != null ? body : new CompoundNode();
-    this.elseBody = elseBody != null ? elseBody : new CompoundNode();
+    this.body = body != null ? body : EMPTYCOMPOUNDNODE;
+    this.elseBody = elseBody != null ? elseBody : EMPTYCOMPOUNDNODE;
   }
 
   @Override

--- a/src/main/java/com/keronic/majestik/ast/MajestikAbstractVisitor.java
+++ b/src/main/java/com/keronic/majestik/ast/MajestikAbstractVisitor.java
@@ -35,6 +35,7 @@ public abstract class MajestikAbstractVisitor<T> {
       return switch (type) {
         case ADDITIVE_EXPRESSION -> visitAdditiveExpression(node);
         case ASSIGNMENT_EXPRESSION -> visitAssignmentExpression(node);
+        case EQUALITY_EXPRESSION -> visitEqualityExpression(node);
         case FALSE -> visitFalse(node);
         case IDENTIFIER -> visitIdentifier(node);
         case IF -> visitIfExpression(node);
@@ -87,6 +88,10 @@ public abstract class MajestikAbstractVisitor<T> {
   }
 
   protected T visitAdditiveExpression(final AstNode node) {
+    return this.visitDefault(node);
+  }
+
+  protected T visitEqualityExpression(final AstNode node) {
     return this.visitDefault(node);
   }
 

--- a/src/main/java/com/keronic/majestik/ast/MajestikCodeVisitor.java
+++ b/src/main/java/com/keronic/majestik/ast/MajestikCodeVisitor.java
@@ -36,6 +36,19 @@ public class MajestikCodeVisitor extends MajestikAbstractVisitor<Node> {
   }
 
   @Override
+  protected Node visitEqualityExpression(final AstNode node) {
+    var lhs = this.visit(node.getChildren().getFirst());
+    var rhs = this.visit(node.getChildren().getLast());
+    var operator = node.getChildren().get(1).getTokenValue();
+
+    if (!"_is".equals(operator))
+      throw new UnsupportedOperationException(
+          String.format("Not implemented: operator %s ", operator));
+
+    return new IdentityExpressionNode(lhs, rhs);
+  }
+
+  @Override
   protected Node visitFalse(final AstNode node) {
     return new BooleanNode(false);
   }
@@ -52,7 +65,9 @@ public class MajestikCodeVisitor extends MajestikAbstractVisitor<Node> {
     var expression = this.visit(node.getFirstChild(MagikGrammar.CONDITIONAL_EXPRESSION));
 
     var ifbody = this.visit(node.getFirstChild(MagikGrammar.BODY));
-    var elsebody = this.visit(node.getFirstChild(MagikGrammar.ELSE));
+
+    var elsechild = node.getFirstChild(MagikGrammar.ELSE);
+    var elsebody = elsechild != null ? this.visit(elsechild) : null;
 
     return new IfExpressionNode(expression, ifbody, elsebody);
   }

--- a/src/main/java/com/keronic/majestik/constant/ConstantDescs.java
+++ b/src/main/java/com/keronic/majestik/constant/ConstantDescs.java
@@ -9,18 +9,18 @@ public final class ConstantDescs {
   public static final String CLASS_INIT_NAME = java.lang.constant.ConstantDescs.CLASS_INIT_NAME;
 
   public static final ClassDesc CD_boolean = java.lang.constant.ConstantDescs.CD_boolean;
-	public static final ClassDesc CD_double = java.lang.constant.ConstantDescs.CD_double;
+  public static final ClassDesc CD_double = java.lang.constant.ConstantDescs.CD_double;
   public static final ClassDesc CD_int = java.lang.constant.ConstantDescs.CD_int;
-	public static final ClassDesc CD_long = java.lang.constant.ConstantDescs.CD_long;
+  public static final ClassDesc CD_long = java.lang.constant.ConstantDescs.CD_long;
   public static final ClassDesc CD_void = java.lang.constant.ConstantDescs.CD_void;
 
   public static final ClassDesc CD_Boolean = java.lang.constant.ConstantDescs.CD_Boolean;
-	public static final ClassDesc CD_CallSite = java.lang.constant.ConstantDescs.CD_CallSite;
+  public static final ClassDesc CD_CallSite = java.lang.constant.ConstantDescs.CD_CallSite;
   public static final ClassDesc CD_Class = java.lang.constant.ConstantDescs.CD_Class;
-	public static final ClassDesc CD_Double = java.lang.constant.ConstantDescs.CD_Double;
-	public static final ClassDesc CD_Long = java.lang.constant.ConstantDescs.CD_Long;
-	public static final ClassDesc CD_Object = java.lang.constant.ConstantDescs.CD_Object;
-	public static final ClassDesc CD_String = java.lang.constant.ConstantDescs.CD_String;
+  public static final ClassDesc CD_Double = java.lang.constant.ConstantDescs.CD_Double;
+  public static final ClassDesc CD_Long = java.lang.constant.ConstantDescs.CD_Long;
+  public static final ClassDesc CD_Object = java.lang.constant.ConstantDescs.CD_Object;
+  public static final ClassDesc CD_String = java.lang.constant.ConstantDescs.CD_String;
 
   public static final ClassDesc CD_ResultTuple =
       ClassDesc.of("com.keronic.majestik.language.ResultTuple");
@@ -72,12 +72,14 @@ public final class ConstantDescs {
           CD_ConstantBuilder, "stringBootstrap", CD_CallSite, CD_String);
   public static final DirectMethodHandleDesc BSM_TUPLE_BUILDER =
       java.lang.constant.ConstantDescs.ofCallsiteBootstrap(
-	      CD_TupleBuilder, "bootstrap", CD_CallSite);
+          CD_TupleBuilder, "bootstrap", CD_CallSite);
 
   public static final MethodTypeDesc MTD_void = java.lang.constant.ConstantDescs.MTD_void;
 
   public static final MethodTypeDesc MTD_booleanObject =
       MethodTypeDesc.of(ConstantDescs.CD_boolean, ConstantDescs.CD_Object);
+  public static final MethodTypeDesc MTD_booleanObjectObject =
+      MethodTypeDesc.of(ConstantDescs.CD_boolean, ConstantDescs.CD_Object, ConstantDescs.CD_Object);
   public static final MethodTypeDesc MTD_Doubledouble =
       MethodTypeDesc.of(ConstantDescs.CD_Double, ConstantDescs.CD_double);
   public static final MethodTypeDesc MTD_Longlong =
@@ -89,14 +91,25 @@ public final class ConstantDescs {
       MethodTypeDesc.of(ConstantDescs.CD_Object, ConstantDescs.CD_Object, ConstantDescs.CD_Object);
   public static final MethodTypeDesc MTD_ResultTupleObject =
       MethodTypeDesc.of(ConstantDescs.CD_ResultTuple, ConstantDescs.CD_Object);
+  public static final MethodTypeDesc MTD_voidboolean =
+      MethodTypeDesc.of(ConstantDescs.CD_void, ConstantDescs.CD_boolean);
   public static final MethodTypeDesc MTD_voidObject =
       MethodTypeDesc.of(ConstantDescs.CD_void, ConstantDescs.CD_Object);
   public static final MethodTypeDesc MTD_voidObjectObject =
-    MethodTypeDesc.of(ConstantDescs.CD_void, ConstantDescs.CD_Object, ConstantDescs.CD_Object);
+      MethodTypeDesc.of(ConstantDescs.CD_void, ConstantDescs.CD_Object, ConstantDescs.CD_Object);
   public static final MethodTypeDesc MTD_voidObjectObjectObject =
-    MethodTypeDesc.of(ConstantDescs.CD_void, ConstantDescs.CD_Object, ConstantDescs.CD_Object, ConstantDescs.CD_Object);
-public static final MethodTypeDesc MTD_voidClassStringStringint =
-  MethodTypeDesc.of(ConstantDescs.CD_void, ConstantDescs.CD_Class,ConstantDescs.CD_String, ConstantDescs.CD_String, ConstantDescs.CD_int);
+      MethodTypeDesc.of(
+          ConstantDescs.CD_void,
+          ConstantDescs.CD_Object,
+          ConstantDescs.CD_Object,
+          ConstantDescs.CD_Object);
+  public static final MethodTypeDesc MTD_voidClassStringStringint =
+      MethodTypeDesc.of(
+          ConstantDescs.CD_void,
+          ConstantDescs.CD_Class,
+          ConstantDescs.CD_String,
+          ConstantDescs.CD_String,
+          ConstantDescs.CD_int);
   public static final MethodTypeDesc MTD_voidString =
       MethodTypeDesc.of(ConstantDescs.CD_void, ConstantDescs.CD_String);
 }

--- a/src/main/java/com/keronic/majestik/language/utils/MagikObjectUtils.java
+++ b/src/main/java/com/keronic/majestik/language/utils/MagikObjectUtils.java
@@ -16,6 +16,15 @@ public class MagikObjectUtils {
     }
   }
 
+  public static boolean is(Object obj1, Object obj2) {
+    if (obj2 == null) return obj1 == obj2;
+    return switch (obj1) {
+      case null -> obj1 == obj2;
+      case Number num -> num.equals(obj2);
+      default -> false;
+    };
+  }
+
   /** Private constructor to prevent instantiation. */
   private MagikObjectUtils() {}
 }

--- a/src/main/java/com/keronic/majestik/language/utils/MagikObjectUtils.java
+++ b/src/main/java/com/keronic/majestik/language/utils/MagikObjectUtils.java
@@ -21,7 +21,7 @@ public class MagikObjectUtils {
     return switch (obj1) {
       case null -> obj1 == obj2;
       case Number num -> num.equals(obj2);
-      default -> false;
+      default -> obj1 == obj2;
     };
   }
 

--- a/src/test/java/com/keronic/majestik/ast/IdentityExpressionNodeTest.java
+++ b/src/test/java/com/keronic/majestik/ast/IdentityExpressionNodeTest.java
@@ -1,0 +1,74 @@
+package com.keronic.majestik.ast;
+
+import module java.base;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import org.junit.jupiter.api.Test;
+
+class IdentityExpressionNodeTest extends NodeTest {
+  @Test
+  void testEquals() {
+    final var node1 = new IdentityExpressionNode(new VariableNode(0), new VariableNode(1));
+    final var node2 = new IdentityExpressionNode(new VariableNode(0), new VariableNode(1));
+    final var node3 = new IdentityExpressionNode(new VariableNode(0), new VariableNode(2));
+
+    assertEquals(node1, node2);
+
+    assertNotEquals(node1, node3);
+    assertNotEqualsNull(node2);
+  }
+
+  @Test
+  void testHashCode() {
+    final var node1 = new IdentityExpressionNode(new VariableNode(0), new CompoundNode());
+    final var node2 = new IdentityExpressionNode(new VariableNode(0), new CompoundNode());
+
+    assertEquals(node1.hashCode(), node2.hashCode());
+  }
+
+  @Test
+  void testToString() {
+    final var node = new IdentityExpressionNode(new VariableNode(1), new NoOperationNode());
+    assertEquals(
+        "IdentityExpressionNode{lhs=VariableNode{idx=1},rhs=NoOperationNode{}}", node.toString());
+  }
+
+  @Test
+  void shouldGenerateInvokeDynamicInstruction() {
+    final var cnode = new IdentityExpressionNode(new NumberNode(1l), new NumberNode(2l));
+
+    final var code = this.compileInto(cnode::compileInto);
+    assertEquals(9, code.elementList().size());
+    final var cel = code.elementList().toArray(new CodeElement[0]);
+
+    final var consins0 = (ConstantInstruction) cel[0];
+    assertEquals(TypeKind.LongType, consins0.typeKind());
+    final var consins1 = (ConstantInstruction) cel[2];
+    assertEquals(TypeKind.LongType, consins1.typeKind());
+
+    final var invins0 = (InvokeInstruction) cel[1];
+    assertEquals("valueOf", invins0.name().toString());
+    assertEquals("java/lang/Long", invins0.owner().asInternalName());
+
+    final var invins1 = (InvokeInstruction) cel[3];
+    assertEquals("valueOf", invins1.name().toString());
+    assertEquals("java/lang/Long", invins1.owner().asInternalName());
+
+    final var invins2 = (InvokeInstruction) cel[4];
+    assertEquals("is", invins2.name().toString());
+    assertEquals(
+        "com/keronic/majestik/language/utils/MagikObjectUtils", invins2.owner().asInternalName());
+
+    assertInstanceOf(NewObjectInstruction.class, cel[5]);
+    assertInstanceOf(StackInstruction.class, cel[6]);
+    assertInstanceOf(StackInstruction.class, cel[7]);
+    assertInstanceOf(InvokeInstruction.class, cel[8]);
+
+    final var invins3 = (InvokeInstruction) cel[8];
+    assertEquals(ConstantDescs.INIT_NAME, invins3.name().toString());
+    assertEquals("java/lang/Boolean", invins3.owner().asInternalName());
+  }
+}

--- a/src/test/java/com/keronic/majestik/ast/MajestikCodeVisitorTest.java
+++ b/src/test/java/com/keronic/majestik/ast/MajestikCodeVisitorTest.java
@@ -49,7 +49,8 @@ class MajestikCodeVisitorTest {
     var cnode = (CompoundNode) node;
     assertEquals(1, cnode.getChildCount(), "Expected one addtive node");
     var child0 = cnode.getChild(0);
-    assertInstanceOf(AdditiveExpressionNode.class, child0, "First child should be AdditiveExpressionNode");
+    assertInstanceOf(
+        AdditiveExpressionNode.class, child0, "First child should be AdditiveExpressionNode");
   }
 
   @Test
@@ -71,6 +72,25 @@ class MajestikCodeVisitorTest {
   }
 
   @Test
+  void testVisitEqualityExpression() {
+    // Test input
+    var mcv = new MajestikCodeVisitor();
+    var mf = new MagikFile(MagikFile.DEFAULT_URI, ("1 _is _true%n").formatted());
+
+    // Execute
+    var node = mcv.scanFile(mf);
+
+    // Verify
+    assertNotNull(node, "Result should not be null");
+    assertInstanceOf(CompoundNode.class, node, "Expected CompoundNode");
+    var cnode = (CompoundNode) node;
+    assertEquals(1, cnode.getChildCount(), "Expected one equality expression node");
+    var child0 = cnode.getChild(0);
+    assertInstanceOf(
+        IdentityExpressionNode.class, child0, "First child should be IdentityExpressionNode");
+  }
+
+  @Test
   void testVisitIfExpression() {
     // Test input
     var mcv = new MajestikCodeVisitor();
@@ -87,7 +107,6 @@ class MajestikCodeVisitorTest {
     var child0 = cnode.getChild(0);
     assertInstanceOf(IfExpressionNode.class, child0, "First child should be IfExpressionNode");
   }
-
 
   @Test
   void testVisitInvoke() {

--- a/src/test/java/com/keronic/majestik/language/utils/MagikObjectUtilsTest.java
+++ b/src/test/java/com/keronic/majestik/language/utils/MagikObjectUtilsTest.java
@@ -1,7 +1,9 @@
 package com.keronic.majestik.language.utils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.keronic.majestik.MajestikRuntimeException;
 import org.junit.jupiter.api.Test;
@@ -17,5 +19,13 @@ class MagikObjectUtilsTest {
         () -> {
           MagikObjectUtils.should_be_boolean(null);
         });
+  }
+
+  @Test
+  void testIs() {
+    assertTrue(MagikObjectUtils.is(1l, 1l));
+    assertTrue(MagikObjectUtils.is(null, null));
+    assertFalse(MagikObjectUtils.is(Boolean.FALSE, Boolean.TRUE));
+    assertFalse(MagikObjectUtils.is(0l, null));
   }
 }

--- a/src/test/magik/identity_comparison.magik
+++ b/src/test/magik/identity_comparison.magik
@@ -1,0 +1,8 @@
+_block
+	_if 987 _is 987
+	_then
+		write("success")
+	_else
+		write("FAIL")
+	_endif
+_endblock

--- a/src/test/magik/test_cases.json
+++ b/src/test/magik/test_cases.json
@@ -20,25 +20,20 @@
             "description": "Test string output with newline",
             "expected": "Hello\nWorld!"
         },
-	{
-	    "file": "addition.magik",
-	    "description": "Test addition",
-	    "expected": "66666"
-	},
         {
-	    "file": "addition.magik",
-	    "description": "Test addition",
-	    "expected": "66666"
-	},
+            "file": "addition.magik",
+            "description": "Test addition",
+            "expected": "66666"
+        },
         {
             "file": "ifexpression.magik",
             "description": "Test if expression",
             "expected": "success"
         },
-	{
-	    "file": "identity_comparison.magik",
-	    "description": "Test if expression",
-	    "expected": "success"
-	}
+        {
+            "file": "identity_comparison.magik",
+            "description": "Test if expression",
+            "expected": "success"
+        }
     ]
 }

--- a/src/test/magik/test_cases.json
+++ b/src/test/magik/test_cases.json
@@ -20,6 +20,11 @@
             "description": "Test string output with newline",
             "expected": "Hello\nWorld!"
         },
+	{
+	    "file": "addition.magik",
+	    "description": "Test addition",
+	    "expected": "66666"
+	},
         {
 	    "file": "addition.magik",
 	    "description": "Test addition",
@@ -29,6 +34,11 @@
             "file": "ifexpression.magik",
             "description": "Test if expression",
             "expected": "success"
-        }
+        },
+	{
+	    "file": "identity_comparison.magik",
+	    "description": "Test if expression",
+	    "expected": "success"
+	}
     ]
 }

--- a/src/test/magik/test_cases.json
+++ b/src/test/magik/test_cases.json
@@ -32,7 +32,7 @@
         },
         {
             "file": "identity_comparison.magik",
-            "description": "Test if expression",
+            "description": "Test identity comparison using _is operator",
             "expected": "success"
         }
     ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced the `IdentityExpressionNode` class for handling identity expressions.
	- Added support for equality expressions in the `MajestikCodeVisitor`.
	- New utility method `is` in `MagikObjectUtils` for comparing objects.

- **Bug Fixes**
	- Improved handling of null values in `visitIfExpression`.

- **Tests**
	- Added unit tests for `IdentityExpressionNode` and `MagikObjectUtils`.
	- New test cases for `identity_comparison.magik` in the test suite, including identity comparison using the `_is` operator.

- **Chores**
	- Minor formatting adjustments for consistency in method type descriptors and existing test cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->