### PR TITLE
Update Java build to JDK 24; refactor code and add mapping feature

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -25,10 +25,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - name: Set up JDK 23
+    - name: Set up JDK 24
       uses: actions/setup-java@v4
       with:
-        java-version: '23'
+        java-version: '24'
         distribution: 'temurin'
         cache: maven
     - name: Clean with Maven

--- a/README.md
+++ b/README.md
@@ -63,13 +63,13 @@ FAQ
 
 ---
 
-* Q: Why does Majestik require JDK 23?
-  A: Majestik uses the Class-File API[^3], which was introduced as a preview feature in Java 23.
+* Q: Why does Majestik require JDK 24?
+  A: Majestik uses the Class-File API[^3], which was introduced as a permanent feature in Java 24.
 
 * Q: Can generated class files be used in a (Smallworld) Magik session?
-  A: Yes, they can be used in a Magik session, provided the Magik session is started with JDK 23 and preview features are enabled.
+  A: Yes, they can be used in a Magik session, provided the Magik session is started with JDK 24.
 
 [^1]: [Magik (programming language) on Wikipedia](https://en.wikipedia.org/wiki/Magik_(programming_language))
 [^2]: [Magik-Tools](https://github.com/StevenLooman/magik-tools)
-[^3]: [Class-File API](https://docs.oracle.com/en/java/javase/23/docs/api/java.base/java/lang/classfile/package-summary.html)
+[^3]: [Class-File API](https://docs.oracle.com/en/java/javase/24/docs/api/java.base/java/lang/classfile/package-summary.html)
 [^4]: [Magik Hello World example](https://en.wikipedia.org/wiki/Magik_(programming_language)#Hello_World_example)

--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,8 @@
   <properties>
     <dependency.junit.version>5.12.2</dependency.junit.version>
     <dependency.magik-tools.version>0.10.1</dependency.magik-tools.version>
-    <maven.compiler.source>23</maven.compiler.source>
-    <maven.compiler.target>23</maven.compiler.target>
+    <maven.compiler.source>24</maven.compiler.source>
+    <maven.compiler.target>24</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     <sonar.java.enablePreview>true</sonar.java.enablePreview>
@@ -65,6 +65,9 @@
           <configuration>
             <compilerArgs>
               <arg>--enable-preview</arg>
+              <arg>-Xlint:all,-preview</arg>
+              <arg>--add-exports</arg>
+              <arg>java.base/jdk.internal.classfile.components=ALL-UNNAMED</arg>
             </compilerArgs>
           </configuration>
         </plugin>
@@ -108,7 +111,7 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>3.5.3</version>
           <configuration>
-            <argLine>@{argLine} -Djava.util.logging.config.file=src/test/resources/jul.properties --enable-preview</argLine>
+            <argLine>@{argLine} -Djava.util.logging.config.file=src/test/resources/jul.properties --add-exports java.base/jdk.internal.classfile.components=ALL-UNNAMED --enable-preview</argLine>
           </configuration>
         </plugin>
       </plugins>

--- a/src/main/java/com/keronic/MajestikClassLoader.java
+++ b/src/main/java/com/keronic/MajestikClassLoader.java
@@ -1,13 +1,12 @@
 package com.keronic;
 
 import module java.base;
-
-import jdk.internal.classfile.components.ClassRemapper;
+import java.lang.classfile.Annotation;
 
 /** */
 public class MajestikClassLoader extends ClassLoader {
 
-  static final Function<ClassDesc, ClassDesc> REMAP_FUNCTION =
+  private final Function<ClassDesc, ClassDesc> REMAP_FUNCTION =
       cd ->
           ClassDesc.of(
               cd.packageName().replace("com.gesmallworld.magik", "com.keronic.majestik"),
@@ -21,26 +20,787 @@ public class MajestikClassLoader extends ClassLoader {
   protected Class<?> findClass(String name) throws ClassNotFoundException {
     if (name.startsWith("magik") || name.startsWith("majestik")) {
       try {
-        var cd = this.loadClassData(name);
-        return super.defineClass(name, cd, 0, cd.length);
+        ClassLoadingResult result = this.loadClassData(name);
+        // Since loadClassData is expected to return byte[], and now it won't,
+        // this defineClass call will fail if cd is null or not a byte array.
+        // For the purpose of this FQN test, we might need to make loadClassData return null
+        // and handle that in findClass, or let it throw an IOException that findClass catches.
+        // The subtask implies loadClassData should still declare `throws IOException`.
+        if (result == null
+            || result.getClassBytes()
+                == null) { // Or check if it's the dummy byte array if we made one
+          throw new ClassNotFoundException(
+              name + " (Majestik: loadClassData returned null or empty bytes)");
+        }
+        return super.defineClass(
+            result.getRemappedClassName(),
+            result.getClassBytes(),
+            0,
+            result.getClassBytes().length);
       } catch (IOException e) {
-        return super.findClass(name);
+        // If loadClassData throws an IOException (e.g. "Not implemented for test"),
+        // this catch block will handle it.
+        // Depending on the test, we might want loadClassData to throw or return null.
+        // For a pure FQN resolution test, loadClassData just needs to compile.
+        // The original code had `return super.findClass(name);` here.
+        throw new ClassNotFoundException(name, e);
       }
     }
     return super.findClass(name);
   }
 
-  private byte[] loadClassData(String className) throws IOException {
-    var fileName = className.replace('.', File.separatorChar) + ".class";
+  private static class ClassLoadingResult {
+    final byte[] classBytes;
+    final String remappedClassName;
 
-    // ClassFile instance for parsing and transforming the class file
-    var cf = ClassFile.of(ClassFile.ConstantPoolSharingOption.NEW_POOL);
-    // ClassModel representing the parsed class file
-    var cm = cf.parse(Path.of(fileName));
-    // ClassRemapper for applying the REMAP_FUNCTION
-    var crm = ClassRemapper.of(REMAP_FUNCTION);
+    ClassLoadingResult(byte[] classBytes, String remappedClassName) {
+      this.classBytes = classBytes;
+      this.remappedClassName = remappedClassName;
+    }
 
-    // Transform the class file, applying the REMAP_FUNCTION to update package names
-    return cf.transformClass(cm, crm);
+    byte[] getClassBytes() {
+      return classBytes;
+    }
+
+    String getRemappedClassName() {
+      return remappedClassName;
+    }
+  }
+
+  private ClassLoadingResult loadClassData(String className) throws IOException {
+    var classFileName = className.replace('.', File.separatorChar) + ".class";
+    byte[] classBytes;
+    try {
+      Path path = Path.of(classFileName);
+      if (!Files.exists(path)) {
+        InputStream is = getResourceAsStream(classFileName);
+        if (is == null) {
+          throw new IOException(
+              "Class file not found: " + classFileName + " via direct path or resource stream.");
+        }
+        classBytes = is.readAllBytes();
+      } else {
+        classBytes = Files.readAllBytes(path);
+      }
+    } catch (IOException e) {
+      throw new IOException("Failed to read class file: " + classFileName, e);
+    }
+
+    ClassModel classModel;
+    try {
+      classModel = ClassFile.of().parse(classBytes);
+    } catch (Exception e) {
+      throw new IOException("Failed to parse class file: " + classFileName, e);
+    }
+
+    ClassDesc originalThisClassDesc = classModel.thisClass().asSymbol();
+    ClassDesc remappedThisClassDesc = REMAP_FUNCTION.apply(originalThisClassDesc);
+
+    byte[] transformedBytes =
+        ClassFile.of()
+            .build(
+                remappedThisClassDesc,
+                classBuilder -> {
+                  // Apply original model's version and flags (excluding ThisClass name)
+                  if (classModel.majorVersion() > 0) {
+                    classBuilder.withVersion(classModel.majorVersion(), classModel.minorVersion());
+                  }
+                  classBuilder.withFlags(classModel.flags().flagsMask());
+
+                  for (ClassElement ce : classModel) { // classModel is iterable
+                    if (ce instanceof ClassFileVersion) {
+                      // Version is set via classBuilder.withVersion(...) earlier
+                      continue;
+                    } else if (ce instanceof Superclass sc) {
+                      if (sc.superclassEntry() != null) {
+                        ClassDesc remappedSuperDesc = mapTypeDesc(sc.superclassEntry().asSymbol());
+                        if (remappedSuperDesc != null
+                            && !remappedSuperDesc.equals(sc.superclassEntry().asSymbol())) {
+                          classBuilder.withSuperclass(remappedSuperDesc);
+                        } else {
+                          classBuilder.with(sc);
+                        }
+                      } else {
+                        classBuilder.with(sc);
+                      }
+                    } else if (ce instanceof Interfaces ins) {
+                      List<ClassEntry> remappedInterfaces =
+                          ins.interfaces().stream()
+                              .map(
+                                  ifaceEntry ->
+                                      classBuilder
+                                          .constantPool()
+                                          .classEntry(mapTypeDesc(ifaceEntry.asSymbol())))
+                              .toList();
+                      boolean interfacesChanged =
+                          !listEquals(
+                              ins.interfaces(),
+                              remappedInterfaces,
+                              (orig, rem) -> orig.asSymbol().equals(rem.asSymbol()));
+                      if (interfacesChanged) {
+                        classBuilder.withInterfaces(remappedInterfaces);
+                      } else {
+                        classBuilder.with(ins);
+                      }
+                    } else if (ce instanceof SignatureAttribute sigAttr) {
+                      Utf8Entry originalSignatureEntry = sigAttr.signature();
+                      Utf8Entry remappedSignatureEntry =
+                          mapSignatureString(originalSignatureEntry, classBuilder.constantPool());
+                      if (originalSignatureEntry != remappedSignatureEntry) {
+                        classBuilder.with(SignatureAttribute.of(remappedSignatureEntry));
+                      } else {
+                        classBuilder.with(sigAttr);
+                      }
+                    } else if (ce instanceof InnerClassesAttribute ica) {
+                      List<InnerClassInfo> remappedInnerClasses =
+                          ica.classes().stream()
+                              .map(
+                                  ici -> {
+                                    ClassDesc originalInner = ici.innerClass().asSymbol();
+                                    Optional<ClassDesc> originalOuter =
+                                        ici.outerClass().map(ClassEntry::asSymbol);
+                                    Optional<Utf8Entry> originalInnerName = ici.innerName();
+                                    int flags = ici.flagsMask();
+
+                                    ClassDesc remappedInner = mapTypeDesc(originalInner);
+                                    Optional<ClassDesc> remappedOuter =
+                                        originalOuter.map(this::mapTypeDesc);
+
+                                    if (originalInner != remappedInner
+                                        || !originalOuter.equals(remappedOuter)) {
+                                      Optional<ClassEntry> remappedOuterEntry =
+                                          remappedOuter.map(
+                                              cd -> classBuilder.constantPool().classEntry(cd));
+                                      return InnerClassInfo.of(
+                                          classBuilder.constantPool().classEntry(remappedInner),
+                                          remappedOuterEntry,
+                                          originalInnerName,
+                                          flags);
+                                    }
+                                    return ici;
+                                  })
+                              .toList();
+
+                      boolean innerClassesChanged =
+                          !listEquals(ica.classes(), remappedInnerClasses, (o, r) -> o == r);
+                      if (innerClassesChanged) {
+                        classBuilder.with(InnerClassesAttribute.of(remappedInnerClasses));
+                      } else {
+                        classBuilder.with(ica);
+                      }
+                    } else if (ce instanceof EnclosingMethodAttribute ema) {
+                      ClassDesc remappedEnclosingClass =
+                          mapTypeDesc(ema.enclosingClass().asSymbol());
+                      Optional<NameAndTypeEntry> originalMethodNat = ema.enclosingMethod();
+                      Optional<NameAndTypeEntry> remappedMethodNat =
+                          originalMethodNat.map(
+                              nat -> {
+                                MethodTypeDesc originalTypeDesc =
+                                    MethodTypeDesc.ofDescriptor(nat.type().stringValue());
+                                MethodTypeDesc remappedDesc = mapMethodDesc(originalTypeDesc);
+                                // If type changed, create new NameAndTypeEntry
+                                return originalTypeDesc == remappedDesc
+                                    ? nat
+                                    : classBuilder
+                                        .constantPool()
+                                        .nameAndTypeEntry(nat.name().stringValue(), remappedDesc);
+                              });
+
+                      if (!remappedEnclosingClass.equals(ema.enclosingClass().asSymbol())
+                          || !originalMethodNat.equals(remappedMethodNat)) {
+                        classBuilder.with(
+                            EnclosingMethodAttribute.of(
+                                classBuilder.constantPool().classEntry(remappedEnclosingClass),
+                                remappedMethodNat));
+                      } else {
+                        classBuilder.with(ema);
+                      }
+                    } else if (ce instanceof RuntimeVisibleAnnotationsAttribute rva) {
+                      List<Annotation> remappedAnnotations =
+                          mapAnnotations(rva.annotations(), classBuilder.constantPool());
+                      if (!listEquals(rva.annotations(), remappedAnnotations, (o, r) -> o == r)) {
+                        classBuilder.with(
+                            RuntimeVisibleAnnotationsAttribute.of(remappedAnnotations));
+                      } else {
+                        classBuilder.with(rva);
+                      }
+                    } else if (ce instanceof RuntimeInvisibleAnnotationsAttribute ria) {
+                      List<Annotation> remappedAnnotations =
+                          mapAnnotations(ria.annotations(), classBuilder.constantPool());
+                      if (!listEquals(ria.annotations(), remappedAnnotations, (o, r) -> o == r)) {
+                        classBuilder.with(
+                            RuntimeInvisibleAnnotationsAttribute.of(remappedAnnotations));
+                      } else {
+                        classBuilder.with(ria);
+                      }
+                    } else if (ce instanceof NestHostAttribute nha) {
+                      ClassDesc remappedHost = mapTypeDesc(nha.nestHost().asSymbol());
+                      if (!remappedHost.equals(nha.nestHost().asSymbol())) {
+                        classBuilder.with(
+                            NestHostAttribute.of(
+                                classBuilder.constantPool().classEntry(remappedHost)));
+                      } else {
+                        classBuilder.with(nha);
+                      }
+                    } else if (ce instanceof NestMembersAttribute nma) {
+                      List<ClassEntry> remappedMembers =
+                          nma.nestMembers().stream()
+                              .map(
+                                  memberEntry ->
+                                      classBuilder
+                                          .constantPool()
+                                          .classEntry(mapTypeDesc(memberEntry.asSymbol())))
+                              .toList();
+                      if (!listEquals(
+                          nma.nestMembers(),
+                          remappedMembers,
+                          (o, r) -> o.asSymbol().equals(r.asSymbol()))) {
+                        classBuilder.with(NestMembersAttribute.of(remappedMembers));
+                      } else {
+                        classBuilder.with(nma);
+                      }
+                    } else if (ce instanceof PermittedSubclassesAttribute psa) {
+                      List<ClassEntry> remappedSubclasses =
+                          psa.permittedSubclasses().stream()
+                              .map(
+                                  subclassEntry ->
+                                      classBuilder
+                                          .constantPool()
+                                          .classEntry(mapTypeDesc(subclassEntry.asSymbol())))
+                              .toList();
+                      if (!listEquals(
+                          psa.permittedSubclasses(),
+                          remappedSubclasses,
+                          (o, r) -> o.asSymbol().equals(r.asSymbol()))) {
+                        classBuilder.with(PermittedSubclassesAttribute.of(remappedSubclasses));
+                      } else {
+                        classBuilder.with(psa);
+                      }
+                    } else if (ce instanceof MethodModel mm) {
+                      classBuilder.withMethod(
+                          mm.methodName().stringValue(),
+                          mapMethodDesc(mm.methodTypeSymbol()),
+                          mm.flags().flagsMask(), // Restore flags as a direct parameter
+                          mb ->
+                              mb.transform(mm, createMethodRemappingTransform(mb.constantPool())));
+                    } else if (ce instanceof FieldModel fm) {
+                      classBuilder.withField(
+                          fm.fieldName().stringValue(),
+                          mapTypeDesc(fm.fieldTypeSymbol()), // Field type is remapped here
+                          // No flags argument here
+                          fb -> {
+                            fb.withFlags(fm.flags().flagsMask()); // Flags set here
+                            fb.transform(fm, createFieldRemappingTransform(fb.constantPool()));
+                          });
+                    } else {
+                      classBuilder.with(ce);
+                    }
+                  }
+                });
+
+    String remappedNameStr;
+    if (remappedThisClassDesc.isArray()) {
+      // For arrays, descriptorString is already close to binary name (e.g., "[Ljava/lang/String;")
+      // Class.getName() for arrays returns the descriptor string (e.g. "[Ljava.lang.String;").
+      // Ensure internal slashes are dots for defineClass if that's the expectation for array
+      // component FQNs.
+      // However, descriptorString usually uses slashes for internal names.
+      // ClassLoader.defineClass expects dot-separated names for the class itself.
+      // For arrays, "[[Lcom.foo.Bar;" is the binary name.
+      // descriptorString() for ClassDesc like "com/foo/Bar[]" is "[Lcom/foo/Bar;"
+      // So, this should be correct.
+      remappedNameStr = remappedThisClassDesc.descriptorString().replace('/', '.');
+    } else if (remappedThisClassDesc.isPrimitive()) {
+      // For primitives, displayName is the name (e.g., "int", "float")
+      remappedNameStr = remappedThisClassDesc.displayName();
+    } else { // Class or Interface
+      String packageName = remappedThisClassDesc.packageName();
+      String simpleClassName = remappedThisClassDesc.displayName(); // Unqualified name
+      if (packageName.isEmpty()) {
+        remappedNameStr = simpleClassName;
+      } else {
+        remappedNameStr = packageName + "." + simpleClassName;
+      }
+    }
+    return new ClassLoadingResult(transformedBytes, remappedNameStr);
+  }
+
+  // New instance method
+  private ClassDesc mapTypeDesc(ClassDesc desc) {
+    if (desc == null) return null;
+    if (desc.isPrimitive()) {
+      return desc;
+    }
+    if (desc.isArray()) {
+      ClassDesc ultimateElementType = desc;
+      int rank = 0;
+      while (ultimateElementType.isArray()) {
+        ultimateElementType = ultimateElementType.componentType();
+        rank++;
+      }
+      ClassDesc remappedUltimateElementType = mapTypeDesc(ultimateElementType);
+
+      if (ultimateElementType == remappedUltimateElementType) {
+        return desc;
+      } else {
+        return remappedUltimateElementType.arrayType(rank);
+      }
+    }
+    return this.REMAP_FUNCTION.apply(desc);
+  }
+
+  // New instance method
+  private MethodTypeDesc mapMethodDesc(MethodTypeDesc desc) {
+    if (desc == null) return null;
+    ClassDesc remappedReturnType = mapTypeDesc(desc.returnType());
+    List<ClassDesc> remappedParameterTypes =
+        desc.parameterList().stream().map(this::mapTypeDesc).toList();
+    boolean changed =
+        !remappedReturnType.equals(desc.returnType())
+            || !remappedParameterTypes.equals(desc.parameterList());
+
+    if (changed) {
+      return MethodTypeDesc.of(
+          remappedReturnType, remappedParameterTypes.toArray(new ClassDesc[0]));
+    } else {
+      return desc;
+    }
+  }
+
+  private CodeTransform createCodeRemappingTransform() { // Renamed, made instance, no params
+    return (cob, coe) -> { // cob is CodeBuilder, coe is CodeElement
+      switch (coe) {
+        case InvokeInstruction instr:
+          cob.invoke(
+              instr.opcode(),
+              this.mapTypeDesc(instr.owner().asSymbol()),
+              instr.name().stringValue(),
+              this.mapMethodDesc(instr.typeSymbol()),
+              instr.isInterface());
+          break;
+        case FieldInstruction fai:
+          cob.fieldAccess(
+              fai.opcode(),
+              this.mapTypeDesc(fai.owner().asSymbol()),
+              fai.name().stringValue(),
+              this.mapTypeDesc(fai.typeSymbol()));
+          break;
+        case TypeCheckInstruction instr:
+          Opcode typeCheckOpcode = instr.opcode();
+          ClassDesc remappedTypeForTypeCheck = this.mapTypeDesc(instr.type().asSymbol());
+          if (typeCheckOpcode == Opcode.INSTANCEOF) {
+            cob.instanceOf(remappedTypeForTypeCheck);
+          } else if (typeCheckOpcode == Opcode.CHECKCAST) {
+            cob.checkcast(remappedTypeForTypeCheck);
+          } else {
+            cob.with(instr);
+          }
+          break;
+        case NewObjectInstruction instr:
+          cob.new_(this.mapTypeDesc(instr.className().asSymbol()));
+          break;
+        case NewReferenceArrayInstruction instr:
+          cob.anewarray(this.mapTypeDesc(instr.componentType().asSymbol()));
+          break;
+        case NewMultiArrayInstruction instr:
+          cob.multianewarray(this.mapTypeDesc(instr.arrayType().asSymbol()), instr.dimensions());
+          break;
+        case ConstantInstruction.LoadConstantInstruction ldcInstr:
+          ConstantDesc originalConstant = ldcInstr.constantValue();
+          ConstantDesc remappedConstant = mapConstantDesc(originalConstant, cob.constantPool());
+          if (remappedConstant != originalConstant) {
+            cob.ldc(remappedConstant);
+          } else {
+            cob.with(ldcInstr);
+          }
+          break;
+        case InvokeDynamicInstruction idi:
+          {
+            DirectMethodHandleDesc originalBootstrapMethod = idi.bootstrapMethod();
+            List<ConstantDesc> originalBootstrapArgs = idi.bootstrapArgs(); // Corrected
+            String methodName = idi.name().stringValue(); // Corrected
+            MethodTypeDesc originalMethodType = idi.typeSymbol();
+
+            DirectMethodHandleDesc remappedBootstrapMethod =
+                mapDirectMethodHandle(originalBootstrapMethod, cob.constantPool());
+            List<ConstantDesc> remappedBootstrapArgs =
+                originalBootstrapArgs.stream()
+                    .map(arg -> mapConstantDesc(arg, cob.constantPool()))
+                    .toList();
+            MethodTypeDesc remappedMethodType = mapMethodDesc(originalMethodType);
+
+            boolean bootstrapMethodChanged = (originalBootstrapMethod != remappedBootstrapMethod);
+            boolean methodTypeChanged = (originalMethodType != remappedMethodType);
+            boolean bootstrapArgsChanged =
+                !listEquals(originalBootstrapArgs, remappedBootstrapArgs, (o, r) -> o == r);
+
+            if (bootstrapMethodChanged || methodTypeChanged || bootstrapArgsChanged) {
+              cob.invokedynamic(
+                  DynamicCallSiteDesc.of(
+                      remappedBootstrapMethod,
+                      methodName,
+                      remappedMethodType,
+                      remappedBootstrapArgs.toArray(new ConstantDesc[0])));
+            } else {
+              cob.with(idi);
+            }
+            break;
+          }
+        default:
+          cob.with(coe);
+          break;
+      }
+    };
+  }
+
+  private FieldTransform createFieldRemappingTransform(ConstantPoolBuilder fieldCp) {
+    return (fieldBuilder, fieldElement) -> {
+      switch (fieldElement) {
+        case SignatureAttribute sigAttr:
+          {
+            Utf8Entry originalSignatureEntry = sigAttr.signature();
+            Utf8Entry remappedSignatureEntry = mapSignatureString(originalSignatureEntry, fieldCp);
+            if (originalSignatureEntry != remappedSignatureEntry) {
+              fieldBuilder.with(SignatureAttribute.of(remappedSignatureEntry));
+            } else {
+              fieldBuilder.with(sigAttr);
+            }
+            break;
+          }
+        case RuntimeVisibleAnnotationsAttribute rva:
+          {
+            List<Annotation> remappedAnnotations = mapAnnotations(rva.annotations(), fieldCp);
+            if (remappedAnnotations != rva.annotations()) {
+              fieldBuilder.with(RuntimeVisibleAnnotationsAttribute.of(remappedAnnotations));
+            } else {
+              fieldBuilder.with(rva);
+            }
+            break;
+          }
+        case RuntimeInvisibleAnnotationsAttribute ria:
+          {
+            List<Annotation> remappedAnnotations = mapAnnotations(ria.annotations(), fieldCp);
+            if (remappedAnnotations != ria.annotations()) {
+              fieldBuilder.with(RuntimeInvisibleAnnotationsAttribute.of(remappedAnnotations));
+            } else {
+              fieldBuilder.with(ria);
+            }
+            break;
+          }
+        // ConstantValueAttribute will fall to default
+        default:
+          fieldBuilder.with(fieldElement);
+          break;
+      }
+    };
+  }
+
+  private MethodTransform createMethodRemappingTransform(ConstantPoolBuilder methodCp) {
+    return (methodBuilder, methodElement) -> {
+      switch (methodElement) {
+        case CodeAttribute codeAttr:
+          methodBuilder.transformCode(codeAttr, createCodeRemappingTransform());
+          break;
+        case SignatureAttribute sigAttr:
+          {
+            Utf8Entry originalSignatureEntry = sigAttr.signature();
+            Utf8Entry remappedSignatureEntry = mapSignatureString(originalSignatureEntry, methodCp);
+            if (originalSignatureEntry != remappedSignatureEntry) {
+              methodBuilder.with(SignatureAttribute.of(remappedSignatureEntry));
+            } else {
+              methodBuilder.with(sigAttr);
+            }
+            break;
+          }
+        case ExceptionsAttribute ea:
+          {
+            List<ClassEntry> remappedExceptions =
+                ea.exceptions().stream()
+                    .map(e -> methodCp.classEntry(mapTypeDesc(e.asSymbol())))
+                    .toList();
+            boolean changed =
+                ea.exceptions().size() != remappedExceptions.size()
+                    || !listEquals(
+                        ea.exceptions(),
+                        remappedExceptions,
+                        (o, r) -> o.asSymbol().equals(r.asSymbol()));
+            if (changed) {
+              methodBuilder.with(ExceptionsAttribute.of(remappedExceptions));
+            } else {
+              methodBuilder.with(ea);
+            }
+            break;
+          }
+        case RuntimeVisibleAnnotationsAttribute rva:
+          {
+            List<Annotation> remappedAnnotations = mapAnnotations(rva.annotations(), methodCp);
+            if (remappedAnnotations != rva.annotations()) {
+              methodBuilder.with(RuntimeVisibleAnnotationsAttribute.of(remappedAnnotations));
+            } else {
+              methodBuilder.with(rva);
+            }
+            break;
+          }
+        case RuntimeInvisibleAnnotationsAttribute ria:
+          {
+            List<Annotation> remappedAnnotations = mapAnnotations(ria.annotations(), methodCp);
+            if (remappedAnnotations != ria.annotations()) {
+              methodBuilder.with(RuntimeInvisibleAnnotationsAttribute.of(remappedAnnotations));
+            } else {
+              methodBuilder.with(ria);
+            }
+            break;
+          }
+        default:
+          methodBuilder.with(methodElement);
+          break;
+      }
+    };
+  }
+
+  // remapClassDescRecursively is now mapTypeDesc (instance method)
+  // The old static version is removed by this diff.
+
+  private ConstantDesc mapConstantDesc(ConstantDesc constantDesc, ConstantPoolBuilder cp) {
+    if (constantDesc == null) {
+      return null;
+    }
+
+    return switch (constantDesc) {
+      case ClassDesc cd -> mapTypeDesc(cd); // mapTypeDesc returns ClassDesc
+      case MethodTypeDesc mtd -> mapMethodDesc(mtd); // mapMethodDesc returns MethodTypeDesc
+      case String originalString -> {
+        String remappedString = originalString;
+        // Revised String remapping logic for general strings:
+        String tempRemappedString =
+            originalString.replace("com.gesmallworld.magik", "com.keronic.majestik");
+        if (!originalString.equals(tempRemappedString)) {
+          remappedString = tempRemappedString;
+        } else {
+          // Try slash form only if dot form didn't match
+          tempRemappedString =
+              originalString.replace("com/gesmallworld/magik", "com/keronic/majestik");
+          if (!originalString.equals(tempRemappedString)) {
+            remappedString = tempRemappedString;
+          }
+        }
+
+        if (!originalString.equals(remappedString)) {
+          yield remappedString; // Yield the remapped String object directly
+        } else {
+          yield originalString; // Yield the original String object
+        }
+      }
+      case DirectMethodHandleDesc dmhd -> mapDirectMethodHandle(dmhd, cp);
+      case DynamicConstantDesc<?> dcd -> mapDynamicConstantDesc(dcd, cp);
+      default -> constantDesc;
+    };
+  }
+
+  private DirectMethodHandleDesc mapDirectMethodHandle(
+      DirectMethodHandleDesc dmhd, ConstantPoolBuilder cp) {
+    if (dmhd == null) {
+      return null;
+    }
+
+    ClassDesc remappedOwner = mapTypeDesc(dmhd.owner());
+    String methodName = dmhd.methodName();
+
+    boolean ownerChanged = (remappedOwner != dmhd.owner());
+
+    switch (dmhd.kind()) {
+      case GETTER, SETTER, STATIC_GETTER, STATIC_SETTER:
+        ClassDesc fieldType = ClassDesc.ofDescriptor(dmhd.lookupDescriptor());
+        ClassDesc remappedFieldType = mapTypeDesc(fieldType);
+        if (ownerChanged || fieldType != remappedFieldType) {
+          return MethodHandleDesc.ofField(
+              dmhd.kind(), remappedOwner, methodName, remappedFieldType);
+        }
+        break;
+      default:
+        MethodTypeDesc methodType = MethodTypeDesc.ofDescriptor(dmhd.lookupDescriptor());
+        MethodTypeDesc remappedMethodType = mapMethodDesc(methodType);
+        if (ownerChanged || methodType != remappedMethodType) {
+          return MethodHandleDesc.ofMethod(
+              dmhd.kind(), remappedOwner, methodName, remappedMethodType);
+        }
+        break;
+    }
+    return dmhd;
+  }
+
+  private DynamicConstantDesc<?> mapDynamicConstantDesc(
+      DynamicConstantDesc<?> dcd, ConstantPoolBuilder cp) {
+    if (dcd == null) {
+      return null;
+    }
+
+    DirectMethodHandleDesc originalBootstrapMethod = dcd.bootstrapMethod();
+    DirectMethodHandleDesc remappedBootstrapMethod =
+        mapDirectMethodHandle(originalBootstrapMethod, cp);
+
+    String constantName = dcd.constantName();
+
+    ClassDesc originalConstantType = dcd.constantType();
+    ClassDesc remappedConstantType = mapTypeDesc(originalConstantType);
+
+    List<ConstantDesc> originalBootstrapArgs = dcd.bootstrapArgsList();
+    List<ConstantDesc> remappedBootstrapArgs =
+        originalBootstrapArgs.stream().map(arg -> mapConstantDesc(arg, cp)).toList();
+
+    boolean bootstrapMethodChanged = (originalBootstrapMethod != remappedBootstrapMethod);
+    boolean constantTypeChanged = (originalConstantType != remappedConstantType);
+    boolean bootstrapArgsChanged =
+        !listEquals(originalBootstrapArgs, remappedBootstrapArgs, (o, r) -> o == r);
+
+    if (bootstrapMethodChanged || constantTypeChanged || bootstrapArgsChanged) {
+      return DynamicConstantDesc.ofNamed(
+          remappedBootstrapMethod,
+          constantName,
+          remappedConstantType,
+          remappedBootstrapArgs.toArray(new ConstantDesc[0]));
+    } else {
+      return dcd;
+    }
+  }
+
+  private <T> boolean listEquals(List<T> list1, List<T> list2, BiPredicate<T, T> equality) {
+    if (list1 == list2) return true;
+    if (list1.size() != list2.size()) return false;
+    for (int i = 0; i < list1.size(); i++) {
+      if (!equality.test(list1.get(i), list2.get(i))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  // Helper method for mapAnnotations, assuming it's similar to how other list transformations are
+  // handled
+  private List<Annotation> mapAnnotations(
+      List<Annotation> originalAnnotations, ConstantPoolBuilder cp) {
+    List<Annotation> remappedAnnotations =
+        originalAnnotations.stream().map(ann -> mapAnnotation(ann, cp)).toList();
+    // Determine if any annotation actually changed.
+    boolean changed = false;
+    for (int i = 0; i < originalAnnotations.size(); i++) {
+      if (originalAnnotations.get(i)
+          != remappedAnnotations.get(
+              i)) { // Relies on mapAnnotation returning original if no change
+        changed = true;
+        break;
+      }
+    }
+    return changed ? remappedAnnotations : originalAnnotations;
+  }
+
+  private AnnotationValue mapAnnotationValue(AnnotationValue val, ConstantPoolBuilder cp) {
+    if (val == null) return null;
+    return switch (val) {
+      case AnnotationValue.OfAnnotation oa ->
+          AnnotationValue.ofAnnotation(mapAnnotation(oa.annotation(), cp));
+      case AnnotationValue.OfArray arr -> {
+        List<AnnotationValue> remappedValues =
+            arr.values().stream().map(v -> mapAnnotationValue(v, cp)).toList();
+        // Check if any value actually changed to avoid unnecessary new array creation
+        boolean changed = false;
+        if (remappedValues.size() != arr.values().size()) { // Should not happen with toList()
+          changed = true;
+        } else {
+          for (int i = 0; i < remappedValues.size(); i++) {
+            if (remappedValues.get(i)
+                != arr.values()
+                    .get(
+                        i)) { // Reference check, assumes mapAnnotationValue returns original if no
+                              // change
+              changed = true;
+              break;
+            }
+          }
+        }
+        yield changed ? AnnotationValue.ofArray(remappedValues) : arr;
+      }
+      case AnnotationValue.OfClass oc -> {
+        ClassDesc originalClassDesc = oc.classSymbol();
+        ClassDesc remappedClassDesc = mapTypeDesc(originalClassDesc);
+        yield originalClassDesc == remappedClassDesc
+            ? oc
+            : AnnotationValue.ofClass(remappedClassDesc);
+      }
+      case AnnotationValue.OfEnum oe -> {
+        ClassDesc originalEnumClassDesc = oe.classSymbol();
+        ClassDesc remappedEnumClassDesc = mapTypeDesc(originalEnumClassDesc);
+        // Name typically doesn't need remapping unless it's also a class name pattern
+        yield originalEnumClassDesc == remappedEnumClassDesc
+            ? oe
+            : AnnotationValue.ofEnum(remappedEnumClassDesc, oe.constantName().stringValue());
+      }
+      // Default for OfConstant (String, int, long, float, double, short, byte, char, boolean)
+      // These typically don't contain class names that need remapping in this context.
+      default -> val;
+    };
+  }
+
+  private Annotation mapAnnotation(Annotation ann, ConstantPoolBuilder cp) {
+    if (ann == null) return null;
+
+    ClassDesc originalAnnotationType = ann.classSymbol();
+    ClassDesc remappedAnnotationType = mapTypeDesc(originalAnnotationType);
+
+    List<AnnotationElement> originalElements = ann.elements();
+    List<AnnotationElement> remappedElements =
+        originalElements.stream()
+            .map(
+                el -> {
+                  AnnotationValue originalValue = el.value();
+                  AnnotationValue remappedValue = mapAnnotationValue(originalValue, cp);
+                  // If value changed, create new element, else return original
+                  return originalValue == remappedValue
+                      ? el
+                      : AnnotationElement.of(el.name(), remappedValue);
+                })
+            .toList();
+
+    boolean typeChanged = originalAnnotationType != remappedAnnotationType;
+    boolean elementsChanged = false;
+    if (originalElements.size() != remappedElements.size()) { // Should not happen
+      elementsChanged = true;
+    } else {
+      for (int i = 0; i < originalElements.size(); i++) {
+        if (originalElements.get(i) != remappedElements.get(i)) { // Reference check
+          elementsChanged = true;
+          break;
+        }
+      }
+    }
+
+    if (typeChanged || elementsChanged) {
+      return Annotation.of(remappedAnnotationType, remappedElements);
+    } else {
+      return ann; // Return original if nothing changed
+    }
+  }
+
+  private Utf8Entry mapSignatureString(Utf8Entry signatureUtf8Entry, ConstantPoolBuilder cp) {
+    if (signatureUtf8Entry == null) {
+      return null;
+    }
+    String originalSignature = signatureUtf8Entry.stringValue();
+    String remappedSignature = originalSignature;
+
+    // Order matters: specific (with L) before general
+    remappedSignature =
+        remappedSignature.replace("Lcom/gesmallworld/magik/", "Lcom/keronic/majestik/");
+    remappedSignature =
+        remappedSignature.replace("com/gesmallworld/magik/", "com/keronic/majestik/");
+
+    // Less common in signatures, but for safety:
+    remappedSignature = remappedSignature.replace("com.gesmallworld.magik", "com.keronic.majestik");
+
+    if (!originalSignature.equals(remappedSignature)) {
+      return cp.utf8Entry(remappedSignature);
+    } else {
+      return signatureUtf8Entry;
+    }
   }
 }

--- a/src/main/java/com/keronic/MajestikClassLoader.java
+++ b/src/main/java/com/keronic/MajestikClassLoader.java
@@ -1,7 +1,8 @@
-/** */
 package com.keronic;
 
 import module java.base;
+
+import jdk.internal.classfile.components.ClassRemapper;
 
 /** */
 public class MajestikClassLoader extends ClassLoader {
@@ -12,25 +13,24 @@ public class MajestikClassLoader extends ClassLoader {
               cd.packageName().replace("com.gesmallworld.magik", "com.keronic.majestik"),
               cd.displayName());
 
-	public MajestikClassLoader() {
-		// TODO Auto-generated constructor stub
-		super("Majestik", getSystemClassLoader());
-	}
+  public MajestikClassLoader() {
+    super("Majestik", getSystemClassLoader());
+  }
 
-	@Override
-	protected Class<?> findClass(String name) throws ClassNotFoundException {
+  @Override
+  protected Class<?> findClass(String name) throws ClassNotFoundException {
     if (name.startsWith("magik") || name.startsWith("majestik")) {
-			try {
-				var cd = this.loadClassData(name);
-				return super.defineClass(name, cd, 0, cd.length);
-			} catch (IOException e) {
-		    return super.findClass(name);
-			}
-		}
-		return super.findClass(name);
-	}
+      try {
+        var cd = this.loadClassData(name);
+        return super.defineClass(name, cd, 0, cd.length);
+      } catch (IOException e) {
+        return super.findClass(name);
+      }
+    }
+    return super.findClass(name);
+  }
 
-	private byte[] loadClassData(String className) throws IOException {
+  private byte[] loadClassData(String className) throws IOException {
     var fileName = className.replace('.', File.separatorChar) + ".class";
 
     // ClassFile instance for parsing and transforming the class file
@@ -38,9 +38,9 @@ public class MajestikClassLoader extends ClassLoader {
     // ClassModel representing the parsed class file
     var cm = cf.parse(Path.of(fileName));
     // ClassRemapper for applying the REMAP_FUNCTION
-		var crm = ClassRemapper.of(REMAP_FUNCTION);
+    var crm = ClassRemapper.of(REMAP_FUNCTION);
 
     // Transform the class file, applying the REMAP_FUNCTION to update package names
-    return cf.transform(cm, crm);
-	}
+    return cf.transformClass(cm, crm);
+  }
 }

--- a/src/main/java/com/keronic/PathUtils.java
+++ b/src/main/java/com/keronic/PathUtils.java
@@ -1,4 +1,3 @@
-/** */
 package com.keronic;
 
 /** */

--- a/src/main/java/com/keronic/majestik/ast/Node.java
+++ b/src/main/java/com/keronic/majestik/ast/Node.java
@@ -23,7 +23,6 @@ public abstract class Node {
     doCompileInto(cc);
   }
 
-  @Override
   /**
    * Compares this node with another object for structural equality. Two nodes are equal if they are
    * of the same type and have equal children.
@@ -31,24 +30,25 @@ public abstract class Node {
    * @param obj The object to compare with
    * @return true if the objects are structurally equal
    */
+  @Override
   public abstract boolean equals(Object obj);
 
-  @Override
   /**
    * Returns a hash code consistent with equals(). Implementations should include all fields used in
    * equals().
    *
    * @return The hash code value
    */
+  @Override
   public abstract int hashCode();
 
-  @Override
   /**
    * Returns a string representation of this node for debugging. The format should include the node
    * type and essential attributes.
    *
    * @return A debug-friendly string representation
    */
+  @Override
   public abstract String toString();
 
   /**

--- a/src/main/java/com/keronic/majestik/language/ResultTuple.java
+++ b/src/main/java/com/keronic/majestik/language/ResultTuple.java
@@ -1,4 +1,3 @@
-/** */
 package com.keronic.majestik.language;
 
 import module java.base;

--- a/src/main/java/com/keronic/majestik/language/invokers/DynamicAccessor.java
+++ b/src/main/java/com/keronic/majestik/language/invokers/DynamicAccessor.java
@@ -1,11 +1,9 @@
-/** */
 package com.keronic.majestik.language.invokers;
 
 import module java.base;
 
 import com.keronic.majestik.internal.Utils;
 
-/** */
 /**
  * Provides dynamic access functionality for the Magik language. This enum-based singleton handles
  * dynamic variable lookups and storage.

--- a/src/main/java/com/keronic/majestik/language/invokers/GlobalAccessor.java
+++ b/src/main/java/com/keronic/majestik/language/invokers/GlobalAccessor.java
@@ -1,4 +1,3 @@
-/** */
 package com.keronic.majestik.language.invokers;
 
 import module java.base;

--- a/src/main/java/com/keronic/majestik/language/invokers/Invoker.java
+++ b/src/main/java/com/keronic/majestik/language/invokers/Invoker.java
@@ -1,4 +1,3 @@
-/** */
 package com.keronic.majestik.language.invokers;
 
 import module java.base;

--- a/src/main/java/com/keronic/majestik/language/invokers/ProcInvoker.java
+++ b/src/main/java/com/keronic/majestik/language/invokers/ProcInvoker.java
@@ -1,4 +1,3 @@
-/** */
 package com.keronic.majestik.language.invokers;
 
 import module java.base;

--- a/src/main/java/com/keronic/majestik/language/utils/ExecutableMagik.java
+++ b/src/main/java/com/keronic/majestik/language/utils/ExecutableMagik.java
@@ -1,4 +1,3 @@
-/** */
 package com.keronic.majestik.language.utils;
 
 /** */

--- a/src/main/java/com/keronic/majestik/runtime/Proc.java
+++ b/src/main/java/com/keronic/majestik/runtime/Proc.java
@@ -1,6 +1,3 @@
-/**
- *
- */
 package com.keronic.majestik.runtime;
 
 import com.keronic.majestik.runtime.internal.ProcImpl;

--- a/src/main/java/com/keronic/majestik/runtime/internal/ProcImpl.java
+++ b/src/main/java/com/keronic/majestik/runtime/internal/ProcImpl.java
@@ -1,4 +1,3 @@
-/** */
 package com.keronic.majestik.runtime.internal;
 
 import module java.base;

--- a/src/main/java/com/keronic/majestik/runtime/objects/Package.java
+++ b/src/main/java/com/keronic/majestik/runtime/objects/Package.java
@@ -1,4 +1,3 @@
-/** */
 package com.keronic.majestik.runtime.objects;
 
 import com.keronic.majestik.runtime.objects.internal.PackageImpl;

--- a/src/main/java/com/keronic/majestik/runtime/objects/internal/PackageImpl.java
+++ b/src/main/java/com/keronic/majestik/runtime/objects/internal/PackageImpl.java
@@ -1,4 +1,3 @@
-/** */
 package com.keronic.majestik.runtime.objects.internal;
 
 import module java.base;

--- a/src/test/java/com/keronic/PathUtilsTest.java
+++ b/src/test/java/com/keronic/PathUtilsTest.java
@@ -1,4 +1,3 @@
-/** */
 package com.keronic;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/com/keronic/majestik/ast/AdditiveExpressionNodeTest.java
+++ b/src/test/java/com/keronic/majestik/ast/AdditiveExpressionNodeTest.java
@@ -45,9 +45,9 @@ class AdditiveExpressionNodeTest extends NodeTest {
     final var cel = code.elementList().toArray(new CodeElement[0]);
 
     final var consins0 = (ConstantInstruction) cel[0];
-    assertEquals(TypeKind.LongType, consins0.typeKind());
+    assertEquals(TypeKind.LONG, consins0.typeKind());
     final var consins1 = (ConstantInstruction) cel[2];
-    assertEquals(TypeKind.LongType, consins1.typeKind());
+    assertEquals(TypeKind.LONG, consins1.typeKind());
 
     final var invins0 = (InvokeInstruction) cel[1];
     assertEquals("valueOf", invins0.name().toString());

--- a/src/test/java/com/keronic/majestik/ast/CharacterNodeTest.java
+++ b/src/test/java/com/keronic/majestik/ast/CharacterNodeTest.java
@@ -13,10 +13,10 @@ class CharacterNodeTest extends NodeTest {
 
     assertEquals(node1, node2);
 
-    assertNotEquals(node1, (char) 'a');
+    assertNotEquals(node1, 'a');
     var node3 = new CharacterNode('b');
     assertNotEquals(node1, node3);
-    var node4 = new CharacterNode((char) ' ');
+    var node4 = new CharacterNode(' ');
     assertNotEqualsNull(node4);
   }
 

--- a/src/test/java/com/keronic/majestik/ast/IdentityExpressionNodeTest.java
+++ b/src/test/java/com/keronic/majestik/ast/IdentityExpressionNodeTest.java
@@ -45,9 +45,9 @@ class IdentityExpressionNodeTest extends NodeTest {
     final var cel = code.elementList().toArray(new CodeElement[0]);
 
     final var consins0 = (ConstantInstruction) cel[0];
-    assertEquals(TypeKind.LongType, consins0.typeKind());
+    assertEquals(TypeKind.LONG, consins0.typeKind());
     final var consins1 = (ConstantInstruction) cel[2];
-    assertEquals(TypeKind.LongType, consins1.typeKind());
+    assertEquals(TypeKind.LONG, consins1.typeKind());
 
     final var invins0 = (InvokeInstruction) cel[1];
     assertEquals("valueOf", invins0.name().toString());

--- a/src/test/java/com/keronic/majestik/ast/NumberNodeTest.java
+++ b/src/test/java/com/keronic/majestik/ast/NumberNodeTest.java
@@ -52,9 +52,9 @@ class NumberNodeTest extends NodeTest {
     assertInstanceOf(InvokeInstruction.class, cel[3]);
 
     var consins0 = (ConstantInstruction) cel[0];
-    assertEquals(TypeKind.LongType, consins0.typeKind());
+    assertEquals(TypeKind.LONG, consins0.typeKind());
     var consins1 = (ConstantInstruction) cel[2];
-    assertEquals(TypeKind.DoubleType, consins1.typeKind());
+    assertEquals(TypeKind.DOUBLE, consins1.typeKind());
 
     var invins0 = (InvokeInstruction) cel[1];
     assertEquals("valueOf", invins0.name().toString());

--- a/src/test/java/com/keronic/majestik/language/invokers/GlobalAccessorTest.java
+++ b/src/test/java/com/keronic/majestik/language/invokers/GlobalAccessorTest.java
@@ -9,7 +9,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.keronic.majestik.constant.ConstantDescs;
 import org.junit.jupiter.api.Test;
 
-/** */
 /** Tests for the GlobalAccessor class which handles global variable storage and retrieval. */
 class GlobalAccessorTest {
   private static final String TEST_PACKAGE = GlobalAccessorTest.class.getPackageName();

--- a/src/test/java/com/keronic/majestik/language/utils/ExecutableMagikTest.java
+++ b/src/test/java/com/keronic/majestik/language/utils/ExecutableMagikTest.java
@@ -22,12 +22,12 @@ class ExecutableMagikTest {
   }
 
   @Test
-  void testExecute() {
+  void shouldReturnCorrectExecutionResult() {
     assertEquals("Execution Result", executableMagik.execute());
   }
 
   @Test
-  void testPreload() {
+  void shouldNotThrowExceptionWhenPreloading() {
     assertDoesNotThrow(() -> executableMagik.preload());
   }
 }

--- a/src/test/java/com/keronic/majestik/language/utils/ExecutableMagikTest.java
+++ b/src/test/java/com/keronic/majestik/language/utils/ExecutableMagikTest.java
@@ -1,0 +1,33 @@
+package com.keronic.majestik.language.utils;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ExecutableMagikTest {
+
+  private ExecutableMagik executableMagik;
+
+  @BeforeEach
+  void setUp() {
+    executableMagik =
+        new ExecutableMagik() {
+          @Override
+          public Object execute() {
+            return "Execution Result";
+          }
+        };
+  }
+
+  @Test
+  void testExecute() {
+    assertEquals("Execution Result", executableMagik.execute());
+  }
+
+  @Test
+  void testPreload() {
+    assertDoesNotThrow(() -> executableMagik.preload());
+  }
+}

--- a/src/test/magik/test.sh
+++ b/src/test/magik/test.sh
@@ -7,7 +7,7 @@ test() {
     printf "\e[33mRunning test for %s\e[0m\n" "$input_file"
 
     # Run the JAR and capture the output
-    output=$(java -jar --enable-preview target/majestik*.jar "$input_file")
+    output=$(java -jar --add-exports java.base/jdk.internal.classfile.components=ALL-UNNAMED --enable-preview target/majestik*.jar "$input_file")
 
     # Compare the output with the expected output
     if [ "$output" = "$expected_output" ]; then


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Upgraded the system’s Java runtime requirement to JDK 24 in the build configuration and continuous integration workflows.
	- Updated Java execution commands to include necessary export directives for internal API access.
- **Documentation**
	- Updated the FAQ and reference links to reflect the new JDK version and the permanent status of the Class-File API.
- **Refactor**
	- Streamlined the internal processes for constructing classes.
	- Enhanced class loading with deep remapping and improved error handling for better maintainability.
- **Style**
	- Cleaned up redundant comment blocks to improve overall code clarity.
- **Tests**
	- Adjusted test assertions for type kind consistency.
	- Introduced a new test class to ensure reliable execution and preloading behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->